### PR TITLE
Feature/#7

### DIFF
--- a/backend/src/main/java/hanglog/member/Member.java
+++ b/backend/src/main/java/hanglog/member/Member.java
@@ -1,0 +1,52 @@
+package hanglog.member;
+
+import static hanglog.global.type.StatusType.USABLE;
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+
+import hanglog.global.type.StatusType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+// todo: status 고민하기
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Member {
+
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String image;
+
+    private LocalDateTime lastLoginDate;
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    @Column(nullable = false)
+    @Enumerated(value = STRING)
+    private StatusType status = USABLE;
+    @Enumerated(value = EnumType.STRING)
+    private MemberState state;
+
+    public Member(Long id, String name, String image) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+    }
+}

--- a/backend/src/main/java/hanglog/member/MemberState.java
+++ b/backend/src/main/java/hanglog/member/MemberState.java
@@ -1,0 +1,8 @@
+package hanglog.member;
+
+public enum MemberState {
+
+    DORMANT,
+    ACTIVE,
+    DELETED
+}

--- a/backend/src/main/java/hanglog/member/config/LoginConfigure.java
+++ b/backend/src/main/java/hanglog/member/config/LoginConfigure.java
@@ -1,0 +1,14 @@
+package hanglog.member.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class LoginConfigure {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/backend/src/main/java/hanglog/member/controller/OAuthLoginController.java
+++ b/backend/src/main/java/hanglog/member/controller/OAuthLoginController.java
@@ -1,0 +1,24 @@
+package hanglog.member.controller;
+
+import hanglog.member.service.OAuthLoginService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/login/oauth2")
+public class OAuthLoginController {
+
+    private final OAuthLoginService oAuthLoginService;
+
+    public OAuthLoginController(final OAuthLoginService oAuthLoginService) {
+        this.oAuthLoginService = oAuthLoginService;
+    }
+
+    @GetMapping("/code/{registrationId}")
+    public void signUp(@RequestParam final String code, @PathVariable final String registrationId) {
+        oAuthLoginService.socialSignUp(code, registrationId);
+    }
+}

--- a/backend/src/main/java/hanglog/member/mapper/GoogleOAuthProvider.java
+++ b/backend/src/main/java/hanglog/member/mapper/GoogleOAuthProvider.java
@@ -1,0 +1,25 @@
+package hanglog.member.mapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class GoogleOAuthProvider extends OAuthProvider {
+
+    public GoogleOAuthProvider(final JsonNode userResourceNode) {
+        super(userResourceNode);
+    }
+
+    @Override
+    public Long getId() {
+        return userResourceNode.get("id").asLong();
+    }
+
+    @Override
+    public String getNickname() {
+        return userResourceNode.get("name").asText();
+    }
+
+    @Override
+    public String getPicture() {
+        return userResourceNode.get("picture").asText();
+    }
+}

--- a/backend/src/main/java/hanglog/member/mapper/KakaoOAuthProvider.java
+++ b/backend/src/main/java/hanglog/member/mapper/KakaoOAuthProvider.java
@@ -1,0 +1,25 @@
+package hanglog.member.mapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class KakaoOAuthProvider extends OAuthProvider {
+
+    protected KakaoOAuthProvider(final JsonNode userResourceNode) {
+        super(userResourceNode);
+    }
+
+    @Override
+    public Long getId() {
+        return userResourceNode.get("id").asLong();
+    }
+
+    @Override
+    public String getNickname() {
+        return userResourceNode.get("properties").get("nickname").asText();
+    }
+
+    @Override
+    public String getPicture() {
+        return userResourceNode.get("properties").get("profile_image").asText();
+    }
+}

--- a/backend/src/main/java/hanglog/member/mapper/OAuthProvider.java
+++ b/backend/src/main/java/hanglog/member/mapper/OAuthProvider.java
@@ -1,0 +1,29 @@
+package hanglog.member.mapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public abstract class OAuthProvider {
+
+    protected final JsonNode userResourceNode;
+
+    protected OAuthProvider(final JsonNode userResourceNode) {
+        this.userResourceNode = userResourceNode;
+    }
+
+    abstract public Long getId();
+
+    abstract public String getNickname();
+
+    abstract public String getPicture();
+
+    // todo : custom exception
+    public static OAuthProvider mappingProvider(final JsonNode userResourceNode, final String registrationId) {
+        if (registrationId.equals("google")) {
+            return new GoogleOAuthProvider(userResourceNode);
+        }
+        if (registrationId.equals("kakao")) {
+            return new KakaoOAuthProvider(userResourceNode);
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/backend/src/main/java/hanglog/member/repository/MemberRepository.java
+++ b/backend/src/main/java/hanglog/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package hanglog.member.repository;
+
+import hanglog.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/backend/src/main/java/hanglog/member/service/OAuthLoginService.java
+++ b/backend/src/main/java/hanglog/member/service/OAuthLoginService.java
@@ -1,0 +1,78 @@
+package hanglog.member.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import hanglog.member.Member;
+import hanglog.member.mapper.OAuthProvider;
+import hanglog.member.repository.MemberRepository;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class OAuthLoginService {
+
+    private final Environment env;
+    private final RestTemplate restTemplate;
+    private final MemberRepository memberRepository;
+
+    public OAuthLoginService(final Environment env, final RestTemplate restTemplate, final MemberRepository memberRepository) {
+        this.env = env;
+        this.restTemplate = restTemplate;
+        this.memberRepository = memberRepository;
+    }
+
+    //todo : exception custom
+    public Member socialSignUp(final String code, final String registrationId) {
+        final String accessToken = getAccessToken(code, registrationId);
+        final JsonNode userResourceNode = getUserResource(accessToken, registrationId);
+
+        final OAuthProvider oAuthProvider = OAuthProvider.mappingProvider(userResourceNode, registrationId);
+        if (memberRepository.existsById(userResourceNode.get("id").asLong())) {
+            throw new IllegalArgumentException("member already exist");
+        }
+
+        final Member member = new Member(oAuthProvider.getId(), oAuthProvider.getNickname(), oAuthProvider.getPicture());
+        return memberRepository.save(member);
+    }
+
+    private String getAccessToken(final String authorizationCode, final String registrationId) {
+
+        final String clientId = env.getProperty("spring.oauth2.client.registration." + registrationId + ".client-id");
+        final String clientSecret = env.getProperty("spring.oauth2.client.registration." + registrationId + ".client-secret");
+        final String redirectUri = env.getProperty("spring.oauth2.client.registration." + registrationId + ".redirect-uri");
+        final String tokenUri = env.getProperty("spring.oauth2.client.registration." + registrationId + ".token-uri");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", authorizationCode);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("grant_type", "authorization_code");
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        final HttpEntity entity = new HttpEntity(params, headers);
+
+        final ResponseEntity<JsonNode> responseNode = restTemplate.exchange(tokenUri, HttpMethod.POST, entity,
+                JsonNode.class);
+        final JsonNode accessTokenNode = responseNode.getBody();
+        return accessTokenNode.get("access_token").asText();
+    }
+
+    private JsonNode getUserResource(final String accessToken, final String registrationId) {
+        final String resourceUri = env.getProperty("spring.oauth2.client.registration." + registrationId + ".user-info");
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        final HttpEntity entity = new HttpEntity(headers);
+        return restTemplate.exchange(resourceUri, HttpMethod.GET, entity, JsonNode.class).getBody();
+    }
+}

--- a/backend/src/test/java/hanglog/feature/MemberFeature.java
+++ b/backend/src/test/java/hanglog/feature/MemberFeature.java
@@ -1,0 +1,32 @@
+package hanglog.feature;
+
+public class MemberFeature {
+    public static final String GOOGLE_USER_INFO_JSON_STRING =
+            "{\"id\":\"123\","
+            + "\"email\":\"test@test.com\","
+            + "\"verified_email\":true,"
+            + "\"name\":\"google_test\","
+            + "\"given_name\":\"google_test\","
+            + "\"family_name\":\"google_test\","
+            + "\"picture\":\"google_image-url\","
+            + "\"locale\":\"ko\"}";
+    public static final String KAKAO_USER_INFO_JSON_STRING =
+                    "{\"id\":123,"
+                    + "\"connected_at\":\"2023-07-13T01:18:52Z\","
+                    + "\"properties\":{"
+                    + "\"nickname\":\"kakao_test\","
+                    + "\"profile_image\":\"kakao_image-url\","
+                    + "\"thumbnail_image\":\"test_thumbnail_image\"},"
+                    + "\"kakao_account\":{\"profile_nickname_needs_agreement\":false,"
+                    + "\"profile_image_needs_agreement\":false,"
+                    + "\"profile\":{"
+                    + "\"nickname\":\"kakao_test\","
+                    + "\"thumbnail_image_url\":\"kakao_image-url\","
+                    + "\"is_default_image\":false},"
+                    + "\"profile_image_url\":\"test_thumbnail_image\","
+                    + "\"has_email\":true,"
+                    + "\"email_needs_agreement\":false,"
+                    + "\"is_email_valid\":true,"
+                    + "\"is_email_verified\":true,"
+                    + "\"email\":\"fruturum@nate.com\"}}";
+}

--- a/backend/src/test/java/hanglog/member/mapper/OAuthProviderTest.java
+++ b/backend/src/test/java/hanglog/member/mapper/OAuthProviderTest.java
@@ -1,0 +1,54 @@
+package hanglog.member.mapper;
+
+import static hanglog.feature.MemberFeature.GOOGLE_USER_INFO_JSON_STRING;
+import static hanglog.feature.MemberFeature.KAKAO_USER_INFO_JSON_STRING;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+
+class OAuthProviderTest {
+    @ParameterizedTest(name = "{0} OAuth2 요청에서 id, 닉네임, 프로필사진을 가져온다.")
+    @MethodSource("oAuthRegisterProvider")
+    void mappingProvider(
+            final String registrationId,
+            final String jsonString,
+            final long expectedId,
+            final String expectedNickname,
+            final String expectedImage
+    ) throws JsonProcessingException {
+
+        // given
+        final JsonNode userResourceNode = new ObjectMapper().readTree(jsonString);
+
+        // when
+        final OAuthProvider oAuthProvider = OAuthProvider.mappingProvider(userResourceNode,registrationId);
+
+        //then
+       assertSoftly(softly->{
+           softly.assertThat(oAuthProvider.getId()).isEqualTo(expectedId);
+           softly.assertThat(oAuthProvider.getNickname()).isEqualTo(expectedNickname);
+           softly.assertThat(oAuthProvider.getPicture()).isEqualTo(expectedImage);
+       });
+    }
+
+    private static Stream<Arguments> oAuthRegisterProvider(){
+        return Stream.of(
+                Arguments.of("google",
+                        GOOGLE_USER_INFO_JSON_STRING,
+                        123l,"google_test","google_image-url"
+                ),
+                Arguments.of("kakao",
+                                KAKAO_USER_INFO_JSON_STRING
+                                ,
+                        123l,"kakao_test","kakao_image-url"
+                )
+        );
+    }
+}

--- a/backend/src/test/java/hanglog/member/service/OAuthLoginServiceTest.java
+++ b/backend/src/test/java/hanglog/member/service/OAuthLoginServiceTest.java
@@ -1,0 +1,89 @@
+package hanglog.member.service;
+
+import static hanglog.feature.MemberFeature.GOOGLE_USER_INFO_JSON_STRING;
+import static hanglog.feature.MemberFeature.KAKAO_USER_INFO_JSON_STRING;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hanglog.member.Member;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvFileSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@SpringBootTest
+class OAuthLoginServiceTest {
+    @Autowired
+    private Environment env;
+    @Mock
+    private RestTemplate restTemplate;
+    @InjectMocks
+    private OAuthLoginService oAuthLoginService;
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"google","kakao"})
+    void socialSignUp( final String registrationId ) throws JsonProcessingException {
+        // given
+        String resourceUri = env.getProperty("spring.oauth2.client.registration." + registrationId + ".user-info");
+        String tokenUri = env.getProperty("spring.oauth2.client.registration." + registrationId + ".token-uri");
+
+        Mockito
+                .when(restTemplate.exchange(tokenUri, HttpMethod.POST,makeEntity(registrationId), JsonNode.class))
+                .thenReturn(ResponseEntity.of(Optional.of(new ObjectMapper().readTree(GOOGLE_USER_INFO_JSON_STRING))));
+        Mockito
+                .when(restTemplate.exchange(resourceUri, HttpMethod.GET,makeEntity(registrationId), JsonNode.class))
+                .thenReturn(ResponseEntity.of(Optional.of(new ObjectMapper().readTree(GOOGLE_USER_INFO_JSON_STRING))));
+
+        // when
+        Member actual = oAuthLoginService.socialSignUp("code",registrationId);
+
+        //then
+        assertSoftly(softly->{
+            softly.assertThat(actual.getId()).isEqualTo(123l);
+            softly.assertThat(actual.getName()).isEqualTo(registrationId+"_test");
+            softly.assertThat(actual.getImage()).isEqualTo(registrationId+"_image_url");
+        });
+    }
+
+    private HttpEntity makeEntity(final String registrationId){
+        String clientId = env.getProperty("spring.oauth2.client.registration." + registrationId + ".client-id");
+        String clientSecret = env.getProperty("spring.oauth2.client.registration." + registrationId + ".client-secret");
+        String redirectUri = env.getProperty("spring.oauth2.client.registration." + registrationId + ".redirect-uri");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", "code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("grant_type", "authorization_code");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        return new HttpEntity(params, headers);
+    }
+}


### PR DESCRIPTION
## 📄 Summary
> 소셜 인증 후 유저 정보를 가져와 member에 저장하는 것까지 구현하였습니다.

## 🙋🏻 More
>
테스트하는데 문제가 있네요 RestTemplate가 nullable이 많은데 mock으로 처리하려고 하니 계속 에러가 뜨네요. acesstoken이 실시간으로 바꿔서 매번 유저 정보를 인가받는 것도 불가능한데 좋은 방법이 있을까요...

그리고 유저의 id는 구글과 카카오의 유저 id를 저장하였습니다.