### PR TITLE
DayLog 조회, 제목 수정 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/docs.adoc
+++ b/backend/src/docs/asciidoc/docs.adoc
@@ -60,3 +60,14 @@ include::{snippets}/day-log-controller-test/get-day-log/path-parameters.adoc[]
 ==== 응답
 include::{snippets}/day-log-controller-test/get-day-log/http-response.adoc[]
 include::{snippets}/day-log-controller-test/get-day-log/response-fields.adoc[]
+
+
+=== DayLog 제목 수정
+
+==== 요청
+include::{snippets}/day-log-controller-test/update-day-log-title/http-request.adoc[]
+include::{snippets}/day-log-controller-test/update-day-log-title/path-parameters.adoc[]
+include::{snippets}/day-log-controller-test/update-day-log-title/request-fields.adoc[]
+
+==== 응답
+include::{snippets}/day-log-controller-test/update-day-log-title/http-response.adoc[]

--- a/backend/src/docs/asciidoc/docs.adoc
+++ b/backend/src/docs/asciidoc/docs.adoc
@@ -46,3 +46,17 @@ include::{snippets}/trip-controller-test/create-trip/request-fields.adoc[]
 ==== 응답
 include::{snippets}/trip-controller-test/create-trip/http-response.adoc[]
 include::{snippets}/trip-controller-test/create-trip/response-headers.adoc[]
+
+
+
+== DayLog API
+
+=== DayLog 조회
+
+==== 요청
+include::{snippets}/day-log-controller-test/get-day-log/http-request.adoc[]
+include::{snippets}/day-log-controller-test/get-day-log/path-parameters.adoc[]
+
+==== 응답
+include::{snippets}/day-log-controller-test/get-day-log/http-response.adoc[]
+include::{snippets}/day-log-controller-test/get-day-log/response-fields.adoc[]

--- a/backend/src/main/java/hanglog/global/BaseEntity.java
+++ b/backend/src/main/java/hanglog/global/BaseEntity.java
@@ -1,5 +1,6 @@
 package hanglog.global;
 
+import static hanglog.global.type.StatusType.DELETED;
 import static hanglog.global.type.StatusType.USABLE;
 import static jakarta.persistence.EnumType.STRING;
 
@@ -10,22 +11,38 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime modifiedAt;
 
     @Column(nullable = false)
     @Enumerated(value = STRING)
     private StatusType status = USABLE;
+
+    protected BaseEntity(final StatusType status) {
+        this.status = status;
+    }
+
+    public boolean isDeleted() {
+        return this.status.equals(DELETED);
+    }
+
+    public void changeStatusToDeleted() {
+        this.status = DELETED;
+    }
 }

--- a/backend/src/main/java/hanglog/trip/domain/DayLog.java
+++ b/backend/src/main/java/hanglog/trip/domain/DayLog.java
@@ -11,6 +11,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,9 +36,17 @@ public class DayLog extends BaseEntity {
     @JoinColumn(name = "trip_id", nullable = false)
     private Trip trip;
 
-    public DayLog(final String title, final Integer ordinal, final Trip trip) {
+    @OneToMany(mappedBy = "dayLog")
+    private List<Item> items;
+
+    public DayLog(final String title, final Integer ordinal, final Trip trip, final List<Item> items) {
         this.title = title;
         this.ordinal = ordinal;
         this.trip = trip;
+        this.items = items;
+    }
+
+    public DayLog(final String title, final Integer ordinal, final Trip trip) {
+        this(title, ordinal, trip, new ArrayList<>());
     }
 }

--- a/backend/src/main/java/hanglog/trip/domain/DayLog.java
+++ b/backend/src/main/java/hanglog/trip/domain/DayLog.java
@@ -39,11 +39,27 @@ public class DayLog extends BaseEntity {
     @OneToMany(mappedBy = "dayLog")
     private List<Item> items;
 
-    public DayLog(final String title, final Integer ordinal, final Trip trip, final List<Item> items) {
+    public DayLog(
+            final Long id,
+            final String title,
+            final Integer ordinal,
+            final Trip trip,
+            final List<Item> items
+    ) {
+        this.id = id;
         this.title = title;
         this.ordinal = ordinal;
         this.trip = trip;
         this.items = items;
+    }
+
+    public DayLog(
+            final String title,
+            final Integer ordinal,
+            final Trip trip,
+            final List<Item> items
+    ) {
+        this(null, title, ordinal, trip, items);
     }
 
     public DayLog(final String title, final Integer ordinal, final Trip trip) {

--- a/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
+++ b/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
@@ -19,7 +19,7 @@ public class DayLogController {
 
     @GetMapping
     public ResponseEntity<DayLogGetResponse> getDayLog(@PathVariable final Long tripId, @PathVariable final Long id) {
-        final DayLogGetResponse response = dayLogService.getDayLogById(id);
+        final DayLogGetResponse response = dayLogService.getById(id);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
+++ b/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
@@ -1,12 +1,16 @@
 package hanglog.trip.presentation;
 
 
+import hanglog.trip.presentation.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.presentation.dto.response.DayLogGetResponse;
 import hanglog.trip.service.DayLogService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +26,12 @@ public class DayLogController {
         final DayLogGetResponse response = dayLogService.getById(id);
         return ResponseEntity.ok(response);
     }
+
+    @PatchMapping
+    public ResponseEntity<Void> updateDayLogTitle(@PathVariable final Long tripId,
+                                                  @PathVariable final Long id,
+                                                  @RequestBody @Valid final DayLogUpdateTitleRequest request) {
+        dayLogService.updateTitle(id, request);
+        return ResponseEntity.noContent().build();
+    }
 }
-
-

--- a/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
+++ b/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
@@ -16,22 +16,25 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/trips/{tripId}/daylog/{id}")
+@RequestMapping("/trips/{tripId}/daylog/{dayLogId}")
 public class DayLogController {
 
     private final DayLogService dayLogService;
 
     @GetMapping
-    public ResponseEntity<DayLogGetResponse> getDayLog(@PathVariable final Long tripId, @PathVariable final Long id) {
-        final DayLogGetResponse response = dayLogService.getById(id);
+    public ResponseEntity<DayLogGetResponse> getDayLog(
+            @PathVariable final Long tripId,
+            @PathVariable final Long dayLogId) {
+        final DayLogGetResponse response = dayLogService.getById(dayLogId);
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping
-    public ResponseEntity<Void> updateDayLogTitle(@PathVariable final Long tripId,
-                                                  @PathVariable final Long id,
-                                                  @RequestBody @Valid final DayLogUpdateTitleRequest request) {
-        dayLogService.updateTitle(id, request);
+    public ResponseEntity<Void> updateDayLogTitle(
+            @PathVariable final Long tripId,
+            @PathVariable final Long dayLogId,
+            @RequestBody @Valid final DayLogUpdateTitleRequest request) {
+        dayLogService.updateTitle(dayLogId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
+++ b/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
@@ -1,0 +1,27 @@
+package hanglog.trip.presentation;
+
+
+import hanglog.trip.presentation.dto.response.DayLogGetResponse;
+import hanglog.trip.service.DayLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trips/{tripId}/daylog/{id}")
+public class DayLogController {
+
+    private final DayLogService dayLogService;
+
+    @GetMapping
+    public ResponseEntity<DayLogGetResponse> getDayLog(@PathVariable final Long tripId, @PathVariable final Long id) {
+        final DayLogGetResponse response = dayLogService.getDayLogById(id);
+        return ResponseEntity.ok(response);
+    }
+}
+
+

--- a/backend/src/main/java/hanglog/trip/presentation/dto/request/DayLogUpdateTitleRequest.java
+++ b/backend/src/main/java/hanglog/trip/presentation/dto/request/DayLogUpdateTitleRequest.java
@@ -1,6 +1,7 @@
 package hanglog.trip.presentation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class DayLogUpdateTitleRequest {
 
     @NotNull(message = "제목을 입력해주세요.")
+    @Size(max = 50, message = "날짜별 제목은 50자를 초과할 수 없습니다.")
     private String title;
 
     public DayLogUpdateTitleRequest(final String title) {

--- a/backend/src/main/java/hanglog/trip/presentation/dto/request/DayLogUpdateTitleRequest.java
+++ b/backend/src/main/java/hanglog/trip/presentation/dto/request/DayLogUpdateTitleRequest.java
@@ -1,0 +1,17 @@
+package hanglog.trip.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DayLogUpdateTitleRequest {
+
+    @NotNull(message = "제목을 입력해주세요.")
+    private String title;
+
+    public DayLogUpdateTitleRequest(final String title) {
+        this.title = title;
+    }
+}

--- a/backend/src/main/java/hanglog/trip/presentation/dto/response/DayLogGetResponse.java
+++ b/backend/src/main/java/hanglog/trip/presentation/dto/response/DayLogGetResponse.java
@@ -1,5 +1,6 @@
 package hanglog.trip.presentation.dto.response;
 
+import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.Item;
 import java.util.List;
 import lombok.Getter;
@@ -13,4 +14,13 @@ public class DayLogGetResponse {
     private final String title;
     private final Integer ordinal;
     private final List<Item> items;
+
+    public static DayLogGetResponse of(final DayLog dayLog) {
+        return new DayLogGetResponse(
+                dayLog.getId(),
+                dayLog.getTitle(),
+                dayLog.getOrdinal(),
+                dayLog.getItems()
+        );
+    }
 }

--- a/backend/src/main/java/hanglog/trip/presentation/dto/response/DayLogGetResponse.java
+++ b/backend/src/main/java/hanglog/trip/presentation/dto/response/DayLogGetResponse.java
@@ -1,0 +1,16 @@
+package hanglog.trip.presentation.dto.response;
+
+import hanglog.trip.domain.Item;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DayLogGetResponse {
+
+    private final Long id;
+    private final String title;
+    private final Integer ordinal;
+    private final List<Item> items;
+}

--- a/backend/src/main/java/hanglog/trip/service/DayLogService.java
+++ b/backend/src/main/java/hanglog/trip/service/DayLogService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class DayLogService {
 
-    public DayLogGetResponse getDayLogById(final Long id) {
+    public DayLogGetResponse getById(final Long id) {
         return new DayLogGetResponse(null, null, null, null);
     }
 }

--- a/backend/src/main/java/hanglog/trip/service/DayLogService.java
+++ b/backend/src/main/java/hanglog/trip/service/DayLogService.java
@@ -1,0 +1,17 @@
+package hanglog.trip.service;
+
+
+import hanglog.trip.presentation.dto.response.DayLogGetResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DayLogService {
+
+    public DayLogGetResponse getDayLogById(final Long id) {
+        return new DayLogGetResponse(null, null, null, null);
+    }
+}

--- a/backend/src/main/java/hanglog/trip/service/DayLogService.java
+++ b/backend/src/main/java/hanglog/trip/service/DayLogService.java
@@ -3,6 +3,7 @@ package hanglog.trip.service;
 
 import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.repository.DayLogRepository;
+import hanglog.trip.presentation.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.presentation.dto.response.DayLogGetResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,5 +20,8 @@ public class DayLogService {
         final DayLog dayLog = dayLogRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("요청한 ID에 해당하는 데이로그가 존재하지 않습니다."));
         return DayLogGetResponse.of(dayLog);
+    }
+
+    public void updateTitle(final Long id, final DayLogUpdateTitleRequest request) {
     }
 }

--- a/backend/src/main/java/hanglog/trip/service/DayLogService.java
+++ b/backend/src/main/java/hanglog/trip/service/DayLogService.java
@@ -23,5 +23,16 @@ public class DayLogService {
     }
 
     public void updateTitle(final Long id, final DayLogUpdateTitleRequest request) {
+        final DayLog dayLog = dayLogRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("요청한 ID에 해당하는 데이로그가 존재하지 않습니다."));
+
+        final DayLog updatedDayLog = new DayLog(
+                dayLog.getId(),
+                request.getTitle(),
+                dayLog.getOrdinal(),
+                dayLog.getTrip(),
+                dayLog.getItems()
+        );
+        dayLogRepository.save(updatedDayLog);
     }
 }

--- a/backend/src/main/java/hanglog/trip/service/DayLogService.java
+++ b/backend/src/main/java/hanglog/trip/service/DayLogService.java
@@ -1,6 +1,8 @@
 package hanglog.trip.service;
 
 
+import hanglog.trip.domain.DayLog;
+import hanglog.trip.domain.repository.DayLogRepository;
 import hanglog.trip.presentation.dto.response.DayLogGetResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,7 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class DayLogService {
 
+    private final DayLogRepository dayLogRepository;
+
     public DayLogGetResponse getById(final Long id) {
-        return new DayLogGetResponse(null, null, null, null);
+        final DayLog dayLog = dayLogRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("요청한 ID에 해당하는 데이로그가 존재하지 않습니다."));
+        return DayLogGetResponse.of(dayLog);
     }
 }

--- a/backend/src/main/java/hanglog/trip/service/DayLogService.java
+++ b/backend/src/main/java/hanglog/trip/service/DayLogService.java
@@ -16,15 +16,19 @@ public class DayLogService {
 
     private final DayLogRepository dayLogRepository;
 
+    @Transactional(readOnly = true)
     public DayLogGetResponse getById(final Long id) {
         final DayLog dayLog = dayLogRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("요청한 ID에 해당하는 데이로그가 존재하지 않습니다."));
+        validateAlreadyDeleted(dayLog);
+
         return DayLogGetResponse.of(dayLog);
     }
 
     public void updateTitle(final Long id, final DayLogUpdateTitleRequest request) {
         final DayLog dayLog = dayLogRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("요청한 ID에 해당하는 데이로그가 존재하지 않습니다."));
+        validateAlreadyDeleted(dayLog);
 
         final DayLog updatedDayLog = new DayLog(
                 dayLog.getId(),
@@ -34,5 +38,12 @@ public class DayLogService {
                 dayLog.getItems()
         );
         dayLogRepository.save(updatedDayLog);
+    }
+
+
+    private void validateAlreadyDeleted(final DayLog dayLog) {
+        if (dayLog.isDeleted()) {
+            throw new IllegalStateException("이미 삭제된 날짜입니다.");
+        }
     }
 }

--- a/backend/src/test/java/hanglog/trip/fixture/DayLogFixture.java
+++ b/backend/src/test/java/hanglog/trip/fixture/DayLogFixture.java
@@ -1,0 +1,21 @@
+package hanglog.trip.fixture;
+
+import hanglog.trip.domain.DayLog;
+import java.util.List;
+
+public final class DayLogFixture {
+
+    public static final DayLog LONDON_DAYLOG = new DayLog(
+            1L,
+            "런던 여행",
+            1,
+            TripFixture.LONDON_TRIP,
+            List.of());
+
+    public static final DayLog UPDATED_LONDON_DAYLOG = new DayLog(
+            1L,
+            "수정된 런던 여행",
+            1,
+            TripFixture.LONDON_TRIP,
+            List.of());
+}

--- a/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
+++ b/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
@@ -28,13 +28,13 @@ class DayLogControllerTest extends RestDocsTest {
     @MockBean
     private DayLogService dayLogService;
 
-    @DisplayName("단일 여행을 생성할 수 있다.")
+    @DisplayName("날짜별 여행을 조회할 수 있다.")
     @Test
     void getDayLog() throws Exception {
         // given
         final DayLogGetResponse response = new DayLogGetResponse(1L, "런던 여행", 1, new ArrayList<>());
 
-        given(dayLogService.getDayLogById(1L))
+        given(dayLogService.getById(1L))
                 .willReturn(response);
 
         // when & then

--- a/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
+++ b/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
@@ -1,20 +1,29 @@
 package hanglog.trip.presentation;
 
 import static hanglog.trip.restdocs.RestDocsConfiguration.field;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hanglog.trip.presentation.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.presentation.dto.response.DayLogGetResponse;
 import hanglog.trip.restdocs.RestDocsTest;
 import hanglog.trip.service.DayLogService;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
@@ -24,6 +33,9 @@ import org.springframework.restdocs.payload.JsonFieldType;
 @WebMvcTest(DayLogController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class DayLogControllerTest extends RestDocsTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private DayLogService dayLogService;
@@ -65,6 +77,37 @@ class DayLogControllerTest extends RestDocsTest {
                                                 .type(JsonFieldType.ARRAY)
                                                 .description("아이템 목록")
                                                 .attributes(field("constraint", "배열"))
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("날짜별 제목을 수정할 수 있다.")
+    @Test
+    void updateDayLogTitle() throws Exception {
+        // given
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest("updated");
+
+        doNothing().when(dayLogService).updateTitle(anyLong(), any(DayLogUpdateTitleRequest.class));
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylog/{dayLogId}", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("tripId")
+                                                .description("여행 ID"),
+                                        parameterWithName("dayLogId")
+                                                .description("날짜별 기록 ID")
+                                ),
+                                requestFields(
+                                        fieldWithPath("title")
+                                                .type(JsonFieldType.STRING)
+                                                .description("수정된 제목")
+                                                .attributes(field("constraint", "문자열"))
                                 )
                         )
                 );

--- a/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
+++ b/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
@@ -1,0 +1,72 @@
+package hanglog.trip.presentation;
+
+import static hanglog.trip.restdocs.RestDocsConfiguration.field;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import hanglog.trip.presentation.dto.response.DayLogGetResponse;
+import hanglog.trip.restdocs.RestDocsTest;
+import hanglog.trip.service.DayLogService;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+
+@WebMvcTest(DayLogController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class DayLogControllerTest extends RestDocsTest {
+
+    @MockBean
+    private DayLogService dayLogService;
+
+    @DisplayName("단일 여행을 생성할 수 있다.")
+    @Test
+    void getDayLog() throws Exception {
+        // given
+        final DayLogGetResponse response = new DayLogGetResponse(1L, "런던 여행", 1, new ArrayList<>());
+
+        given(dayLogService.getDayLogById(1L))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/trips/{tripId}/daylog/{dayLogId}", 1L, 1L))
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("tripId")
+                                                .description("여행 ID"),
+                                        parameterWithName("dayLogId")
+                                                .description("날짜별 기록 ID")
+                                ),
+                                responseFields(
+                                        fieldWithPath("id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("날짜별 기록 ID")
+                                                .attributes(field("constraint", "양의 정수")),
+                                        fieldWithPath("title")
+                                                .type(JsonFieldType.STRING)
+                                                .description("소제목")
+                                                .attributes(field("constraint", "문자열")),
+                                        fieldWithPath("ordinal")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("여행에서의 날짜 순서")
+                                                .attributes(field("constraint", "양의 정수")),
+                                        fieldWithPath("items")
+                                                .type(JsonFieldType.ARRAY)
+                                                .description("아이템 목록")
+                                                .attributes(field("constraint", "배열"))
+                                )
+                        )
+                );
+    }
+}

--- a/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
@@ -1,17 +1,21 @@
 package hanglog.trip.service;
 
+import static hanglog.trip.fixture.DayLogFixture.LONDON_DAYLOG;
+import static hanglog.trip.fixture.DayLogFixture.UPDATED_LONDON_DAYLOG;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.repository.DayLogRepository;
-import hanglog.trip.fixture.TripFixture;
+import hanglog.trip.presentation.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.presentation.dto.response.DayLogGetResponse;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,16 +33,34 @@ class DayLogServiceTest {
     @Test
     void getDayLogById() {
         // given
-        final DayLog dayLog = new DayLog(1L, "런던 여행", 1, TripFixture.LONDON_TRIP, List.of());
         final DayLogGetResponse expected = new DayLogGetResponse(1L, "런던 여행", 1, List.of());
 
-        BDDMockito.given(dayLogRepository.findById(1L))
-                .willReturn(Optional.of(dayLog));
+        given(dayLogRepository.findById(1L))
+                .willReturn(Optional.of(LONDON_DAYLOG));
 
         // when
-        final DayLogGetResponse actual = dayLogService.getById(dayLog.getId());
+        final DayLogGetResponse actual = dayLogService.getById(LONDON_DAYLOG.getId());
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @DisplayName("날짜별 제목을 수정한다.")
+    @Test
+    void updateTitle() {
+        // given
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest("updated");
+
+        given(dayLogRepository.findById(1L))
+                .willReturn(Optional.of(LONDON_DAYLOG));
+        given(dayLogRepository.save(any(DayLog.class)))
+                .willReturn(UPDATED_LONDON_DAYLOG);
+
+        // when
+        dayLogService.updateTitle(LONDON_DAYLOG.getId(), request);
+
+        // then
+        verify(dayLogRepository).findById(UPDATED_LONDON_DAYLOG.getId());
+        verify(dayLogRepository).save(any(DayLog.class));
     }
 }

--- a/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
@@ -1,0 +1,44 @@
+package hanglog.trip.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import hanglog.trip.domain.DayLog;
+import hanglog.trip.domain.repository.DayLogRepository;
+import hanglog.trip.fixture.TripFixture;
+import hanglog.trip.presentation.dto.response.DayLogGetResponse;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DayLogServiceTest {
+
+    @InjectMocks
+    private DayLogService dayLogService;
+
+    @Mock
+    private DayLogRepository dayLogRepository;
+
+    @DisplayName("날짜별 여행을 조회할 수 있다.")
+    @Test
+    void getDayLogById() {
+        // given
+        final DayLog dayLog = new DayLog(1L, "런던 여행", 1, TripFixture.LONDON_TRIP, List.of());
+        final DayLogGetResponse expected = new DayLogGetResponse(1L, "런던 여행", 1, List.of());
+
+        BDDMockito.given(dayLogRepository.findById(1L))
+                .willReturn(Optional.of(dayLog));
+
+        // when
+        final DayLogGetResponse actual = dayLogService.getById(dayLog.getId());
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## 📄 Summary
> #35 #36 
> dayLogId로 날짜 별 기록을 조회하는 기능 구현 완료하였습니다.
> 날짜 기록 별 제목 수정 기능도 구현완료하였습니다.


## 🙋🏻 More
> 제목 수정 구현할게 많지 않길래 기다리지 못하고 합쳐서 커밋했습니다..불편하시다면 죄송합니다..
