### PR TITLE
TripItem 추가 모달 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/styled": "^11.11.0",
         "@tanstack/react-query": "^4.29.19",
         "axios": "^1.4.0",
-        "hang-log-design-system": "^1.1.19",
+        "hang-log-design-system": "^1.1.24",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1",
@@ -12765,9 +12765,9 @@
       }
     },
     "node_modules/hang-log-design-system": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/hang-log-design-system/-/hang-log-design-system-1.1.19.tgz",
-      "integrity": "sha512-uNJb7uRZcNws0ymgvVMboH4ba70PU96dQVrpymWrxm7bbIPvwqLea9cQQGD6ZduJlWqVln+4UsHu57ZwtMGaww==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/hang-log-design-system/-/hang-log-design-system-1.1.24.tgz",
+      "integrity": "sha512-Qh9NUd6t0lg/dXRyZo8naYc6s/2bnK5+7K/cMriPvYIsV4RGz8yGvahYI29GJikqMaf4Wvj/jCq9SkZb34vLQg==",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -28985,9 +28985,9 @@
       }
     },
     "hang-log-design-system": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/hang-log-design-system/-/hang-log-design-system-1.1.19.tgz",
-      "integrity": "sha512-uNJb7uRZcNws0ymgvVMboH4ba70PU96dQVrpymWrxm7bbIPvwqLea9cQQGD6ZduJlWqVln+4UsHu57ZwtMGaww==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/hang-log-design-system/-/hang-log-design-system-1.1.24.tgz",
+      "integrity": "sha512-Qh9NUd6t0lg/dXRyZo8naYc6s/2bnK5+7K/cMriPvYIsV4RGz8yGvahYI29GJikqMaf4Wvj/jCq9SkZb34vLQg==",
       "requires": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "@emotion/styled": "^11.11.0",
     "@tanstack/react-query": "^4.29.19",
     "axios": "^1.4.0",
-    "hang-log-design-system": "^1.1.19",
+    "hang-log-design-system": "^1.1.24",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",

--- a/frontend/src/api/expense/getExpenseCategory.ts
+++ b/frontend/src/api/expense/getExpenseCategory.ts
@@ -1,0 +1,10 @@
+import { END_POINTS } from '@constants/api';
+import type { ExpenseCategoryData } from '@type/expense';
+
+import { axiosInstance } from '@api/axiosInstance';
+
+export const getExpenseCategory = async () => {
+  const { data } = await axiosInstance.get<ExpenseCategoryData[]>(END_POINTS.EXPENSE_CATEGORY);
+
+  return data;
+};

--- a/frontend/src/api/tripItem/postTripItem.ts
+++ b/frontend/src/api/tripItem/postTripItem.ts
@@ -1,4 +1,4 @@
-import { END_POINTS } from '@/constants/api';
+import { END_POINTS } from '@constants/api';
 import type { TripItemFormType } from '@type/tripItem';
 
 import { axiosInstance } from '@api/axiosInstance';

--- a/frontend/src/api/tripItem/postTripItem.ts
+++ b/frontend/src/api/tripItem/postTripItem.ts
@@ -1,0 +1,16 @@
+import { END_POINTS } from '@/constants/api';
+import type { TripItemFormType } from '@type/tripItem';
+
+import { axiosInstance } from '@api/axiosInstance';
+
+export interface PostTripItemParams extends TripItemFormType {
+  tripId: number;
+}
+
+export const postTripItem =
+  () =>
+  ({ tripId, ...information }: PostTripItemParams) => {
+    return axiosInstance.post<TripItemFormType>(END_POINTS.CREATE_TRIP_ITEM(tripId), {
+      ...information,
+    });
+  };

--- a/frontend/src/components/common/DayLogItem/DayLogItem.tsx
+++ b/frontend/src/components/common/DayLogItem/DayLogItem.tsx
@@ -9,9 +9,10 @@ import TripItemList from '@components/common/TripItemList/TripItemList';
 
 interface DayLogItemProps extends DayLogData {
   tripId: number;
+  openAddModal: () => void;
 }
 
-const DayLogItem = ({ tripId, ...information }: DayLogItemProps) => {
+const DayLogItem = ({ tripId, openAddModal, ...information }: DayLogItemProps) => {
   const { selected: selectedFilter, handleSelectClick: handleFilterSelectClick } = useSelect(
     DAY_LOG_ITEM_FILTERS.ALL
   );
@@ -48,7 +49,7 @@ const DayLogItem = ({ tripId, ...information }: DayLogItemProps) => {
       {selectedTripItemList.length > 0 ? (
         <TripItemList tripId={tripId} dayLogId={information.id} tripItems={selectedTripItemList} />
       ) : (
-        <TripItemList.Empty />
+        <TripItemList.Empty openAddModal={openAddModal} />
       )}
     </Box>
   );

--- a/frontend/src/components/common/DayLogList/DayLogList.tsx
+++ b/frontend/src/components/common/DayLogList/DayLogList.tsx
@@ -8,28 +8,30 @@ import { containerStyling } from '@components/common/DayLogList/DayLogList.style
 
 interface DayLogListProps {
   tripId: number;
-  logs: DayLogData[];
+  selectedDayLog: DayLogData;
+  dates: {
+    id: number;
+    date: string;
+  }[];
+  onTabChange: (selectedId: string | number) => void;
 }
 
-const DayLogList = ({ tripId, logs }: DayLogListProps) => {
-  const { selected, handleSelectClick } = useSelect(logs[0].id);
-  const selectedDayLog = logs.find((log) => log.id === selected)!;
-
+const DayLogList = ({ tripId, selectedDayLog, dates, onTabChange }: DayLogListProps) => {
   return (
     <section css={containerStyling}>
       <Tabs>
-        {logs.map((log, index) => (
+        {dates.map((date, index) => (
           <Tab
             key={index}
             text={
-              log.id === selected
-                ? `Day ${log.ordinal} - ${formatMonthDate(log.date)} `
-                : `Day ${log.ordinal}`
+              date.id === selectedDayLog.id
+                ? `Day ${index + 1} - ${formatMonthDate(date.date)} `
+                : `Day ${index + 1}`
             }
             variant="outline"
-            tabId={log.id}
-            selectedId={selected}
-            changeSelect={handleSelectClick}
+            tabId={date.id}
+            selectedId={selectedDayLog.id}
+            changeSelect={onTabChange}
           />
         ))}
       </Tabs>

--- a/frontend/src/components/common/DayLogList/DayLogList.tsx
+++ b/frontend/src/components/common/DayLogList/DayLogList.tsx
@@ -1,5 +1,5 @@
 import type { DayLogData } from '@type/dayLog';
-import { Tab, Tabs, useSelect } from 'hang-log-design-system';
+import { Tab, Tabs } from 'hang-log-design-system';
 
 import { formatMonthDate } from '@utils/formatter';
 
@@ -27,20 +27,35 @@ const DayLogList = ({
   return (
     <section css={containerStyling}>
       <Tabs>
-        {dates.map((date, index) => (
-          <Tab
-            key={index}
-            text={
-              date.id === selectedDayLog.id
-                ? `Day ${index + 1} - ${formatMonthDate(date.date)} `
-                : `Day ${index + 1}`
-            }
-            variant="outline"
-            tabId={date.id}
-            selectedId={selectedDayLog.id}
-            changeSelect={onTabChange}
-          />
-        ))}
+        {dates.map((date, index) => {
+          if (index === dates.length - 1) {
+            return (
+              <Tab
+                key={index}
+                text={'기타'}
+                variant="outline"
+                tabId={date.id}
+                selectedId={selectedDayLog.id}
+                changeSelect={onTabChange}
+              />
+            );
+          }
+
+          return (
+            <Tab
+              key={index}
+              text={
+                date.id === selectedDayLog.id
+                  ? `Day ${index + 1} - ${formatMonthDate(date.date)} `
+                  : `Day ${index + 1}`
+              }
+              variant="outline"
+              tabId={date.id}
+              selectedId={selectedDayLog.id}
+              changeSelect={onTabChange}
+            />
+          );
+        })}
       </Tabs>
       <DayLogItem tripId={tripId} openAddModal={openAddModal} {...selectedDayLog} />
     </section>

--- a/frontend/src/components/common/DayLogList/DayLogList.tsx
+++ b/frontend/src/components/common/DayLogList/DayLogList.tsx
@@ -14,9 +14,16 @@ interface DayLogListProps {
     date: string;
   }[];
   onTabChange: (selectedId: string | number) => void;
+  openAddModal: () => void;
 }
 
-const DayLogList = ({ tripId, selectedDayLog, dates, onTabChange }: DayLogListProps) => {
+const DayLogList = ({
+  tripId,
+  selectedDayLog,
+  dates,
+  onTabChange,
+  openAddModal,
+}: DayLogListProps) => {
   return (
     <section css={containerStyling}>
       <Tabs>
@@ -35,7 +42,7 @@ const DayLogList = ({ tripId, selectedDayLog, dates, onTabChange }: DayLogListPr
           />
         ))}
       </Tabs>
-      <DayLogItem tripId={tripId} {...selectedDayLog} />
+      <DayLogItem tripId={tripId} openAddModal={openAddModal} {...selectedDayLog} />
     </section>
   );
 };

--- a/frontend/src/components/common/TripItem/TripItem.tsx
+++ b/frontend/src/components/common/TripItem/TripItem.tsx
@@ -15,7 +15,7 @@ import {
 } from 'hang-log-design-system';
 import { useState } from 'react';
 
-import { moneyFormatter } from '@utils/formatter';
+import { formatNumberToMoney } from '@utils/formatter';
 
 import StarRating from '@components/common/StarRating/StarRating';
 import {
@@ -87,7 +87,7 @@ const TripItem = ({ onDragStart, onDragEnter, onDragEnd, ...information }: TripL
           {information.expense && (
             <Text css={expenseStyling} size="small">
               {information.expense.category.name} · {CURRENCY_ICON[information.expense.currency]}
-              {moneyFormatter(information.expense.amount)}
+              {formatNumberToMoney(information.expense.amount)}
             </Text>
           )}
         </Box>

--- a/frontend/src/components/common/TripItemList/TripItemList.tsx
+++ b/frontend/src/components/common/TripItemList/TripItemList.tsx
@@ -57,7 +57,7 @@ const TripItemList = ({ tripId, dayLogId, tripItems }: TripItemListProps) => {
   );
 };
 
-TripItemList.Empty = () => {
+TripItemList.Empty = ({ openAddModal }: { openAddModal: () => void }) => {
   return (
     <>
       <Heading size="xSmall">아직 추가된 일정 기록이 없습니다!</Heading>
@@ -65,7 +65,7 @@ TripItemList.Empty = () => {
         여행하면서 갔던 장소, 사용했던 경비와 같은 여행 일정 기록들을 추가해 보세요.
       </Text>
       {/* 클릭하면 일정 추가 모달 열기 */}
-      <Button css={addItemButtonStyling} type="button" variant="primary">
+      <Button css={addItemButtonStyling} type="button" variant="primary" onClick={openAddModal}>
         일정 기록 추가하기
       </Button>
     </>

--- a/frontend/src/components/trip/TripItemAddModal/TripItemAddModal.style.ts
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemAddModal.style.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+import { Theme } from 'hang-log-design-system';
+
+export const formStyling = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: Theme.spacer.spacing4,
+
+  '& > button': {
+    width: '100%',
+  },
+});

--- a/frontend/src/components/trip/TripItemAddModal/TripItemAddModal.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemAddModal.tsx
@@ -1,0 +1,84 @@
+import { Button, Flex, ImageUploadInput, Input, Modal, Theme } from 'hang-log-design-system';
+
+import { useAddTripItemForm } from '@hooks/useAddTripItemForm';
+
+import { formStyling } from '@components/trip/TripItemAddModal/TripItemAddModal.style';
+import TripItemCategoryInput from '@components/trip/TripItemAddModal/TripItemCategoryInput/TripItemCategoryInput';
+import TripItemDateInput from '@components/trip/TripItemAddModal/TripItemDateInput/TripItemDateInput';
+import TripItemExpenseInput from '@components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput';
+import TripItemMemoInput from '@components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput';
+import TripItemStarRatingInput from '@components/trip/TripItemAddModal/TripItemStarRatingInput/TripItemStarRatingInput';
+import TripItemTitleInput from '@components/trip/TripItemAddModal/TripItemTitleInput/TripItemTitleInput';
+
+interface TripItemAddModalProps {
+  isOpen: boolean;
+  tripId: number;
+  currentDate: { id: number; date: string };
+  dates: { id: number; date: string }[];
+  onClose: () => void;
+}
+
+const TripItemAddModal = ({
+  isOpen,
+  tripId,
+  dates,
+  currentDate,
+  onClose,
+}: TripItemAddModalProps) => {
+  const { tripItemInformation, isTitleError, updateInputValue, disableTitleError, handleSubmit } =
+    useAddTripItemForm(tripId, currentDate.id, onClose);
+
+  return (
+    <Modal isOpen={isOpen} closeModal={onClose} hasCloseButton>
+      <form css={formStyling} onSubmit={handleSubmit} noValidate>
+        <Flex styles={{ gap: Theme.spacer.spacing4 }}>
+          <Flex styles={{ direction: 'column', gap: '16px', width: '312px', align: 'stretch' }}>
+            <TripItemCategoryInput
+              initialCategory={tripItemInformation.itemType}
+              updateInputValue={updateInputValue}
+            />
+            <TripItemDateInput
+              currentCategory={tripItemInformation.itemType}
+              initialDate={currentDate.date}
+              dates={dates}
+              updateInputValue={updateInputValue}
+            />
+            {tripItemInformation.itemType ? (
+              <Input label="장소" name="title" required placeholder="장소를 입력해 주세요" />
+            ) : (
+              <TripItemTitleInput
+                isError={isTitleError}
+                initialValue={tripItemInformation.title}
+                updateInputValue={updateInputValue}
+                disableError={disableTitleError}
+              />
+            )}
+            <TripItemStarRatingInput
+              initialRate={tripItemInformation.rating}
+              updateInputValue={updateInputValue}
+            />
+            <TripItemExpenseInput updateInputValue={updateInputValue} />
+          </Flex>
+          <Flex styles={{ direction: 'column', gap: '16px', width: '312px', align: 'stretch' }}>
+            <TripItemMemoInput
+              initialValue={tripItemInformation.memo}
+              updateInputValue={updateInputValue}
+            />
+            {/* TODO : 이미지 업로드 관련 로직 처리 필요함 */}
+            <ImageUploadInput
+              label="이미지 업로드"
+              imageUrls={tripItemInformation.imageUrls}
+              imageAltText="여행 일정 업르드 이미지"
+              supportingText="사진은 최대 5장 올릴 수 있어요."
+              maxUploadCount={5}
+              onRemove={() => {}}
+            />
+          </Flex>
+        </Flex>
+        <Button variant="primary">일정 기록 추가하기</Button>
+      </form>
+    </Modal>
+  );
+};
+
+export default TripItemAddModal;

--- a/frontend/src/components/trip/TripItemAddModal/TripItemAddModal.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemAddModal.tsx
@@ -34,12 +34,12 @@ const TripItemAddModal = ({
         <Flex styles={{ gap: Theme.spacer.spacing4 }}>
           <Flex styles={{ direction: 'column', gap: '16px', width: '312px', align: 'stretch' }}>
             <TripItemCategoryInput
-              initialCategory={tripItemInformation.itemType}
+              itemType={tripItemInformation.itemType}
               updateInputValue={updateInputValue}
             />
             <TripItemDateInput
               currentCategory={tripItemInformation.itemType}
-              initialDate={currentDate.date}
+              currentDate={currentDate.date}
               dates={dates}
               updateInputValue={updateInputValue}
             />
@@ -48,20 +48,20 @@ const TripItemAddModal = ({
             ) : (
               <TripItemTitleInput
                 isError={isTitleError}
-                initialValue={tripItemInformation.title}
+                value={tripItemInformation.title}
                 updateInputValue={updateInputValue}
                 disableError={disableTitleError}
               />
             )}
             <TripItemStarRatingInput
-              initialRate={tripItemInformation.rating}
+              rating={tripItemInformation.rating}
               updateInputValue={updateInputValue}
             />
             <TripItemExpenseInput updateInputValue={updateInputValue} />
           </Flex>
           <Flex styles={{ direction: 'column', gap: '16px', width: '312px', align: 'stretch' }}>
             <TripItemMemoInput
-              initialValue={tripItemInformation.memo}
+              value={tripItemInformation.memo}
               updateInputValue={updateInputValue}
             />
             {/* TODO : 이미지 업로드 관련 로직 처리 필요함 */}

--- a/frontend/src/components/trip/TripItemAddModal/TripItemCategoryInput/TripItemCategoryInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemCategoryInput/TripItemCategoryInput.tsx
@@ -1,0 +1,32 @@
+import type { TripItemFormType } from '@type/tripItem';
+import { RadioButton } from 'hang-log-design-system';
+import type { ChangeEvent } from 'react';
+import { memo } from 'react';
+
+interface TripItemCategoryInputProps {
+  initialCategory: TripItemFormType['itemType'];
+  updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
+}
+
+const TripItemCategoryInput = ({
+  initialCategory,
+  updateInputValue,
+}: TripItemCategoryInputProps) => {
+  const handleCategoryChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const itemType = event.target.id === '장소';
+    updateInputValue('itemType', itemType);
+  };
+
+  return (
+    <RadioButton
+      label="카테고리"
+      required
+      name="trip-item-category"
+      options={['장소', '기타']}
+      initialCheckedOption={initialCategory ? '장소' : '기타'}
+      onChange={handleCategoryChange}
+    />
+  );
+};
+
+export default memo(TripItemCategoryInput);

--- a/frontend/src/components/trip/TripItemAddModal/TripItemCategoryInput/TripItemCategoryInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemCategoryInput/TripItemCategoryInput.tsx
@@ -4,14 +4,11 @@ import type { ChangeEvent } from 'react';
 import { memo } from 'react';
 
 interface TripItemCategoryInputProps {
-  initialCategory: TripItemFormType['itemType'];
+  itemType: TripItemFormType['itemType'];
   updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
 }
 
-const TripItemCategoryInput = ({
-  initialCategory,
-  updateInputValue,
-}: TripItemCategoryInputProps) => {
+const TripItemCategoryInput = ({ itemType, updateInputValue }: TripItemCategoryInputProps) => {
   const handleCategoryChange = (event: ChangeEvent<HTMLInputElement>) => {
     const itemType = event.target.id === '장소';
     updateInputValue('itemType', itemType);
@@ -23,7 +20,7 @@ const TripItemCategoryInput = ({
       required
       name="trip-item-category"
       options={['장소', '기타']}
-      initialCheckedOption={initialCategory ? '장소' : '기타'}
+      initialCheckedOption={itemType ? '장소' : '기타'}
       onChange={handleCategoryChange}
     />
   );

--- a/frontend/src/components/trip/TripItemAddModal/TripItemDateInput/TripItemDateInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemDateInput/TripItemDateInput.tsx
@@ -7,15 +7,13 @@ import { formatMonthDate } from '@utils/formatter';
 
 interface TripItemDateInputProps {
   currentCategory: TripItemFormType['itemType'];
-  dayLogIds: number[];
   initialDate: string;
-  dates: string[];
+  dates: { id: number; date: string }[];
   updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
 }
 
 const TripItemDateInput = ({
   currentCategory,
-  dayLogIds,
   initialDate,
   dates,
   updateInputValue,
@@ -29,20 +27,20 @@ const TripItemDateInput = ({
       <>
         {Array.from({ length: dates.length - 1 }, (_, index) => (
           <option
-            key={dates[index]}
-            value={dayLogIds[index]}
-            selected={initialDate === dates[index]}
+            key={dates[index].id}
+            value={dates[index].id}
+            selected={initialDate === dates[index].date}
           >
-            Day {index + 1} - {formatMonthDate(dates[index])}
+            Day {index + 1} - {formatMonthDate(dates[index].date)}
           </option>
         ))}
       </>
       <>
         {!currentCategory && (
           <option
-            key={dates.at(-1)}
-            value={dayLogIds.at(-1)}
-            selected={initialDate === dates.at(-1)}
+            key={dates.at(-1)?.id}
+            value={dates.at(-1)?.id}
+            selected={initialDate === dates.at(-1)?.date}
           >
             기타
           </option>

--- a/frontend/src/components/trip/TripItemAddModal/TripItemDateInput/TripItemDateInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemDateInput/TripItemDateInput.tsx
@@ -1,0 +1,55 @@
+import type { TripItemFormType } from '@type/tripItem';
+import { Select } from 'hang-log-design-system';
+import type { ChangeEvent } from 'react';
+import { memo } from 'react';
+
+import { formatMonthDate } from '@utils/formatter';
+
+interface TripItemDateInputProps {
+  currentCategory: TripItemFormType['itemType'];
+  dayLogIds: number[];
+  initialDate: string;
+  dates: string[];
+  updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
+}
+
+const TripItemDateInput = ({
+  currentCategory,
+  dayLogIds,
+  initialDate,
+  dates,
+  updateInputValue,
+}: TripItemDateInputProps) => {
+  const handleDateChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    updateInputValue('dayLogId', Number(event.target.value));
+  };
+
+  return (
+    <Select label="날짜" name="date" required onChange={handleDateChange}>
+      <>
+        {Array.from({ length: dates.length - 1 }, (_, index) => (
+          <option
+            key={dates[index]}
+            value={dayLogIds[index]}
+            selected={initialDate === dates[index]}
+          >
+            Day {index + 1} - {formatMonthDate(dates[index])}
+          </option>
+        ))}
+      </>
+      <>
+        {!currentCategory && (
+          <option
+            key={dates.at(-1)}
+            value={dayLogIds.at(-1)}
+            selected={initialDate === dates.at(-1)}
+          >
+            기타
+          </option>
+        )}
+      </>
+    </Select>
+  );
+};
+
+export default memo(TripItemDateInput);

--- a/frontend/src/components/trip/TripItemAddModal/TripItemDateInput/TripItemDateInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemDateInput/TripItemDateInput.tsx
@@ -7,14 +7,14 @@ import { formatMonthDate } from '@utils/formatter';
 
 interface TripItemDateInputProps {
   currentCategory: TripItemFormType['itemType'];
-  initialDate: string;
+  currentDate: string;
   dates: { id: number; date: string }[];
   updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
 }
 
 const TripItemDateInput = ({
   currentCategory,
-  initialDate,
+  currentDate,
   dates,
   updateInputValue,
 }: TripItemDateInputProps) => {
@@ -29,7 +29,7 @@ const TripItemDateInput = ({
           <option
             key={dates[index].id}
             value={dates[index].id}
-            selected={initialDate === dates[index].date}
+            selected={currentDate === dates[index].date}
           >
             Day {index + 1} - {formatMonthDate(dates[index].date)}
           </option>
@@ -40,7 +40,7 @@ const TripItemDateInput = ({
           <option
             key={dates.at(-1)?.id}
             value={dates.at(-1)?.id}
-            selected={initialDate === dates.at(-1)?.date}
+            selected={currentDate === dates.at(-1)?.date}
           >
             기타
           </option>

--- a/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.style.ts
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.style.ts
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import { Theme } from 'hang-log-design-system';
+
+export const leftContainerStyling = css({
+  '& > div > div': {
+    border: 'none',
+  },
+});
+
+export const categorySelectStyling = css({
+  width: '74px',
+  height: '48px',
+  paddingRight: Theme.spacer.spacing1,
+  border: 'none',
+});
+
+export const currencySelectStyling = css({
+  width: '64px',
+  height: '48px',
+  paddingRight: Theme.spacer.spacing1,
+  border: 'none',
+});

--- a/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
@@ -4,7 +4,7 @@ import type { ExpenseCategoryData } from '@type/expense';
 import type { TripItemFormType } from '@type/tripItem';
 import { Flex, Input, Label, Select, Theme } from 'hang-log-design-system';
 import type { ChangeEvent } from 'react';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 
 import {
   categorySelectStyling,
@@ -88,4 +88,4 @@ const TripItemExpenseInput = ({
   );
 };
 
-export default TripItemExpenseInput;
+export default memo(TripItemExpenseInput);

--- a/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
@@ -1,11 +1,8 @@
 import { useTripItemExpenseInput } from '@/hooks/useTripItemExpenseInput';
-import { CURRENCY_ICON, DEFAULT_CURRENCY } from '@constants/trip';
-import { useQueryClient } from '@tanstack/react-query';
-import type { ExpenseCategoryData } from '@type/expense';
+import { CURRENCY_ICON } from '@constants/trip';
 import type { TripItemFormType } from '@type/tripItem';
 import { Flex, Input, Label, Select, Theme } from 'hang-log-design-system';
-import type { ChangeEvent } from 'react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 
 import {
   categorySelectStyling,

--- a/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
@@ -1,4 +1,4 @@
-import { CURRENCY_ICON } from '@constants/trip';
+import { CURRENCY_ICON, DEFAULT_CURRENCY } from '@constants/trip';
 import { useQueryClient } from '@tanstack/react-query';
 import type { ExpenseCategoryData } from '@type/expense';
 import type { TripItemFormType } from '@type/tripItem';
@@ -23,7 +23,7 @@ const TripItemExpenseInput = ({
 }: TripItemExpenseInputProps) => {
   const [_, setExpenseValue] = useState<TripItemFormType['expense']>(
     initialExpenseValue ?? {
-      currency: 'KRW',
+      currency: DEFAULT_CURRENCY,
       categoryId: 100,
       amount: 0,
     }

--- a/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
@@ -1,0 +1,91 @@
+import { CURRENCY_ICON } from '@constants/trip';
+import { useQueryClient } from '@tanstack/react-query';
+import type { ExpenseCategoryData } from '@type/expense';
+import type { TripItemFormType } from '@type/tripItem';
+import { Flex, Input, Label, Select, Theme } from 'hang-log-design-system';
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+
+import {
+  categorySelectStyling,
+  currencySelectStyling,
+  leftContainerStyling,
+} from '@components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.style';
+
+interface TripItemExpenseInputProps {
+  initialExpenseValue?: TripItemFormType['expense'];
+  updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
+}
+
+const TripItemExpenseInput = ({
+  initialExpenseValue,
+  updateInputValue,
+}: TripItemExpenseInputProps) => {
+  const [_, setExpenseValue] = useState<TripItemFormType['expense']>(
+    initialExpenseValue ?? {
+      currency: 'KRW',
+      categoryId: 100,
+      amount: 0,
+    }
+  );
+
+  const queryClient = useQueryClient();
+  const expenseCategoryData = queryClient.getQueryData<ExpenseCategoryData[]>(['expenseCategory'])!;
+
+  const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setExpenseValue((prevExpenseValue) => {
+      const newExpenseValue = { ...prevExpenseValue!, categoryId: Number(event.target.value) };
+
+      if (prevExpenseValue?.amount) updateInputValue('expense', newExpenseValue);
+
+      return newExpenseValue;
+    });
+  };
+
+  const handleCurrencyChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setExpenseValue((prevExpenseValue) => {
+      const newExpenseValue = { ...prevExpenseValue!, currency: event.target.value };
+
+      if (prevExpenseValue?.amount) updateInputValue('expense', newExpenseValue);
+
+      return newExpenseValue;
+    });
+  };
+
+  const handleAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setExpenseValue((prevExpenseValue) => {
+      const newExpenseValue = {
+        ...prevExpenseValue!,
+        amount: Number(event.target.value),
+      };
+      updateInputValue('expense', newExpenseValue.amount === 0 ? null : newExpenseValue);
+
+      return newExpenseValue;
+    });
+  };
+
+  return (
+    <Flex styles={{ direction: 'column', gap: Theme.spacer.spacing2 }}>
+      <Label>비용</Label>
+      <Flex styles={{ gap: Theme.spacer.spacing1 }} css={leftContainerStyling}>
+        <Select css={categorySelectStyling} name="expense-category" onChange={handleCategoryChange}>
+          {expenseCategoryData.map(({ id, name }) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </Select>
+        <Select css={currencySelectStyling} name="expense-currency" onChange={handleCurrencyChange}>
+          {Object.entries(CURRENCY_ICON).map(([key, value], index) => (
+            <option key={key} value={key}>
+              {value}
+            </option>
+          ))}
+        </Select>
+        <Input type="number" placeholder="0" onChange={handleAmountChange} />
+      </Flex>
+    </Flex>
+  );
+};
+
+export default TripItemExpenseInput;

--- a/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemExpenseInput/TripItemExpenseInput.tsx
@@ -1,3 +1,4 @@
+import { useTripItemExpenseInput } from '@/hooks/useTripItemExpenseInput';
 import { CURRENCY_ICON, DEFAULT_CURRENCY } from '@constants/trip';
 import { useQueryClient } from '@tanstack/react-query';
 import type { ExpenseCategoryData } from '@type/expense';
@@ -21,48 +22,8 @@ const TripItemExpenseInput = ({
   initialExpenseValue,
   updateInputValue,
 }: TripItemExpenseInputProps) => {
-  const [_, setExpenseValue] = useState<TripItemFormType['expense']>(
-    initialExpenseValue ?? {
-      currency: DEFAULT_CURRENCY,
-      categoryId: 100,
-      amount: 0,
-    }
-  );
-
-  const queryClient = useQueryClient();
-  const expenseCategoryData = queryClient.getQueryData<ExpenseCategoryData[]>(['expenseCategory'])!;
-
-  const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    setExpenseValue((prevExpenseValue) => {
-      const newExpenseValue = { ...prevExpenseValue!, categoryId: Number(event.target.value) };
-
-      if (prevExpenseValue?.amount) updateInputValue('expense', newExpenseValue);
-
-      return newExpenseValue;
-    });
-  };
-
-  const handleCurrencyChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    setExpenseValue((prevExpenseValue) => {
-      const newExpenseValue = { ...prevExpenseValue!, currency: event.target.value };
-
-      if (prevExpenseValue?.amount) updateInputValue('expense', newExpenseValue);
-
-      return newExpenseValue;
-    });
-  };
-
-  const handleAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setExpenseValue((prevExpenseValue) => {
-      const newExpenseValue = {
-        ...prevExpenseValue!,
-        amount: Number(event.target.value),
-      };
-      updateInputValue('expense', newExpenseValue.amount === 0 ? null : newExpenseValue);
-
-      return newExpenseValue;
-    });
-  };
+  const { expenseCategoryData, handleCategoryChange, handleCurrencyChange, handleAmountChange } =
+    useTripItemExpenseInput(updateInputValue, initialExpenseValue);
 
   return (
     <Flex styles={{ direction: 'column', gap: Theme.spacer.spacing2 }}>

--- a/frontend/src/components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.style.ts
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.style.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const textareaStyling = css({
+  height: '208px',
+
+  resize: 'none',
+});

--- a/frontend/src/components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.tsx
@@ -1,0 +1,33 @@
+import type { TripItemFormType } from '@type/tripItem';
+import { Textarea } from 'hang-log-design-system';
+import type { ChangeEvent } from 'react';
+import { memo, useState } from 'react';
+
+import { textareaStyling } from '@components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.style';
+
+interface TripItemMemoInputProps {
+  initialValue: TripItemFormType['memo'];
+  updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
+}
+
+const TripItemMemoInput = ({ initialValue, updateInputValue }: TripItemMemoInputProps) => {
+  const [value, setValue] = useState<string>(initialValue ?? '');
+
+  const handleMemoChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(event.target.value);
+    updateInputValue('memo', event.target.value);
+  };
+
+  return (
+    <Textarea
+      css={textareaStyling}
+      label="메모"
+      name="memo"
+      value={value}
+      placeholder="메모를 입력해 주세요"
+      onChange={handleMemoChange}
+    />
+  );
+};
+
+export default memo(TripItemMemoInput);

--- a/frontend/src/components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.tsx
@@ -1,20 +1,17 @@
 import type { TripItemFormType } from '@type/tripItem';
 import { Textarea } from 'hang-log-design-system';
 import type { ChangeEvent } from 'react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 
 import { textareaStyling } from '@components/trip/TripItemAddModal/TripItemMemoInput/TripItemMemoInput.style';
 
 interface TripItemMemoInputProps {
-  initialValue: TripItemFormType['memo'];
+  value: TripItemFormType['memo'];
   updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
 }
 
-const TripItemMemoInput = ({ initialValue, updateInputValue }: TripItemMemoInputProps) => {
-  const [value, setValue] = useState<string>(initialValue ?? '');
-
+const TripItemMemoInput = ({ value, updateInputValue }: TripItemMemoInputProps) => {
   const handleMemoChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(event.target.value);
     updateInputValue('memo', event.target.value);
   };
 
@@ -23,7 +20,7 @@ const TripItemMemoInput = ({ initialValue, updateInputValue }: TripItemMemoInput
       css={textareaStyling}
       label="메모"
       name="memo"
-      value={value}
+      value={value ?? ''}
       placeholder="메모를 입력해 주세요"
       onChange={handleMemoChange}
     />

--- a/frontend/src/components/trip/TripItemAddModal/TripItemStarRatingInput/TripItemStarRatingInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemStarRatingInput/TripItemStarRatingInput.tsx
@@ -1,0 +1,37 @@
+import type { StarRatingData, TripItemFormType } from '@type/tripItem';
+import { StarRatingInput, useStarRatingInput } from 'hang-log-design-system';
+import { memo } from 'react';
+
+interface TripItemStarRatingInputProps {
+  initialRate: StarRatingData | null;
+  updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
+}
+
+const TripItemStarRatingInput = ({
+  initialRate,
+  updateInputValue,
+}: TripItemStarRatingInputProps) => {
+  const handleRatingChange = (rate: StarRatingData) => {
+    const newRate = rate || null;
+    updateInputValue('rating', newRate);
+  };
+
+  const { starRate, handleStarClick, handleStarHover, handleStarHoverOut } = useStarRatingInput(
+    initialRate ?? 0,
+    handleRatingChange
+  );
+
+  return (
+    <StarRatingInput
+      label="별점"
+      size={32}
+      gap={8}
+      rate={starRate}
+      onStarClick={handleStarClick}
+      onStarHover={handleStarHover}
+      onStarHoverOut={handleStarHoverOut}
+    />
+  );
+};
+
+export default memo(TripItemStarRatingInput);

--- a/frontend/src/components/trip/TripItemAddModal/TripItemStarRatingInput/TripItemStarRatingInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemStarRatingInput/TripItemStarRatingInput.tsx
@@ -3,21 +3,18 @@ import { StarRatingInput, useStarRatingInput } from 'hang-log-design-system';
 import { memo } from 'react';
 
 interface TripItemStarRatingInputProps {
-  initialRate: StarRatingData | null;
+  rating: StarRatingData | null;
   updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
 }
 
-const TripItemStarRatingInput = ({
-  initialRate,
-  updateInputValue,
-}: TripItemStarRatingInputProps) => {
+const TripItemStarRatingInput = ({ rating, updateInputValue }: TripItemStarRatingInputProps) => {
   const handleRatingChange = (rate: StarRatingData) => {
     const newRate = rate || null;
     updateInputValue('rating', newRate);
   };
 
   const { starRate, handleStarClick, handleStarHover, handleStarHoverOut } = useStarRatingInput(
-    initialRate ?? 0,
+    rating ?? 0,
     handleRatingChange
   );
 

--- a/frontend/src/components/trip/TripItemAddModal/TripItemTitleInput/TripItemTitleInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemTitleInput/TripItemTitleInput.tsx
@@ -1,0 +1,42 @@
+import type { TripItemFormType } from '@type/tripItem';
+import { Input } from 'hang-log-design-system';
+import type { ChangeEvent } from 'react';
+import { memo, useState } from 'react';
+
+interface TripItemTitleInputProps {
+  initialValue: string;
+  isError: boolean;
+  updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
+  disableError: () => void;
+}
+
+const TripItemTitleInput = ({
+  isError,
+  initialValue,
+  updateInputValue,
+  disableError,
+}: TripItemTitleInputProps) => {
+  const [value, setValue] = useState(initialValue);
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (isError) disableError();
+
+    setValue(event.target.value);
+    updateInputValue('title', event.target.value);
+  };
+
+  return (
+    <Input
+      label="제목"
+      name="title"
+      value={value}
+      placeholder="제목을 입력해 주세요"
+      supportingText={isError ? '일정의 제목을 입력해 주세요' : undefined}
+      isError={isError}
+      required
+      onChange={handleTitleChange}
+    />
+  );
+};
+
+export default memo(TripItemTitleInput);

--- a/frontend/src/components/trip/TripItemAddModal/TripItemTitleInput/TripItemTitleInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemTitleInput/TripItemTitleInput.tsx
@@ -1,7 +1,7 @@
 import type { TripItemFormType } from '@type/tripItem';
 import { Input } from 'hang-log-design-system';
 import type { ChangeEvent } from 'react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 
 interface TripItemTitleInputProps {
   value: string;

--- a/frontend/src/components/trip/TripItemAddModal/TripItemTitleInput/TripItemTitleInput.tsx
+++ b/frontend/src/components/trip/TripItemAddModal/TripItemTitleInput/TripItemTitleInput.tsx
@@ -4,7 +4,7 @@ import type { ChangeEvent } from 'react';
 import { memo, useState } from 'react';
 
 interface TripItemTitleInputProps {
-  initialValue: string;
+  value: string;
   isError: boolean;
   updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void;
   disableError: () => void;
@@ -12,16 +12,13 @@ interface TripItemTitleInputProps {
 
 const TripItemTitleInput = ({
   isError,
-  initialValue,
+  value,
   updateInputValue,
   disableError,
 }: TripItemTitleInputProps) => {
-  const [value, setValue] = useState(initialValue);
-
   const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (isError) disableError();
 
-    setValue(event.target.value);
     updateInputValue('title', event.target.value);
   };
 

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -7,7 +7,8 @@ export const END_POINTS = {
   DAY_LOG_ORDER: (tripId: number, dayLogId: number) => `/trips/${tripId}/daylogs/${dayLogId}/order`,
   CREATE_TRIP_ITEM: (tripId: number) => `/trips/${tripId}/items`,
   CHANGE_TRIP_ITEM: (tripId: number, itemId: number) => `/trips/${tripId}/items/${itemId}`,
-  CITIES:'/cities'
+  CITIES: '/cities',
+  EXPENSE_CATEGORY: '/expense-category',
 } as const;
 
 export const NETWORK = {

--- a/frontend/src/constants/trip.ts
+++ b/frontend/src/constants/trip.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_CURRENCY = 'KRW';
+
 export const CURRENCY_ICON = {
   KRW: '₩',
   USD: '$',

--- a/frontend/src/hooks/api/useAddTripItemMutation.ts
+++ b/frontend/src/hooks/api/useAddTripItemMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { postTripItem } from '@api/tripItem/postTripItem';
+
+export const useAddTripItemMutation = (onSuccess?: CallableFunction) => {
+  const queryClient = useQueryClient();
+
+  const addTripItemMutation = useMutation(postTripItem(), {
+    onSuccess: () => {
+      // 순서 변경 성공 시 Trip 정보 재요청
+      queryClient.invalidateQueries({ queryKey: ['trip'] });
+      onSuccess?.();
+    },
+    onError: (err, _, context) => {
+      alert('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+    },
+  });
+
+  return addTripItemMutation;
+};

--- a/frontend/src/hooks/api/useAddTripItemMutation.ts
+++ b/frontend/src/hooks/api/useAddTripItemMutation.ts
@@ -2,14 +2,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postTripItem } from '@api/tripItem/postTripItem';
 
-export const useAddTripItemMutation = (onSuccess?: CallableFunction) => {
+export const useAddTripItemMutation = () => {
   const queryClient = useQueryClient();
 
   const addTripItemMutation = useMutation(postTripItem(), {
     onSuccess: () => {
       // 순서 변경 성공 시 Trip 정보 재요청
       queryClient.invalidateQueries({ queryKey: ['trip'] });
-      onSuccess?.();
     },
     onError: (err, _, context) => {
       alert('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');

--- a/frontend/src/hooks/api/useCityQuery.ts
+++ b/frontend/src/hooks/api/useCityQuery.ts
@@ -8,8 +8,8 @@ import { getCities } from '@api/city/getCities';
 export const useCityQuery = () => {
   const { data: citiesData } = useQuery<CityData[], AxiosError>(['city'], getCities, {
     retry: NETWORK.RETRY_COUNT,
-    // suspense: true,
-    // useErrorBoundary: true,
+    suspense: true,
+    useErrorBoundary: true,
   });
 
   return { citiesData };

--- a/frontend/src/hooks/api/useExpenseCategoryQuery.ts
+++ b/frontend/src/hooks/api/useExpenseCategoryQuery.ts
@@ -1,0 +1,19 @@
+import { ExpenseCategoryData } from '@/types/expense';
+import { NETWORK } from '@constants/api';
+import { useQuery } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+import { getExpenseCategory } from '@api/expense/getExpenseCategory';
+
+export const useExpenseCategoryQuery = () => {
+  const { data } = useQuery<ExpenseCategoryData[], AxiosError>(
+    ['expenseCategory'],
+    getExpenseCategory,
+    {
+      retry: NETWORK.RETRY_COUNT,
+      useErrorBoundary: true,
+    }
+  );
+
+  return { expenseCategoryData: data! };
+};

--- a/frontend/src/hooks/api/useExpenseCategoryQuery.ts
+++ b/frontend/src/hooks/api/useExpenseCategoryQuery.ts
@@ -1,6 +1,6 @@
-import { ExpenseCategoryData } from '@/types/expense';
 import { NETWORK } from '@constants/api';
 import { useQuery } from '@tanstack/react-query';
+import type { ExpenseCategoryData } from '@type/expense';
 import type { AxiosError } from 'axios';
 
 import { getExpenseCategory } from '@api/expense/getExpenseCategory';

--- a/frontend/src/hooks/api/useGetTrips.ts
+++ b/frontend/src/hooks/api/useGetTrips.ts
@@ -1,7 +1,7 @@
 import { NETWORK } from '@constants/api';
 import { useQuery } from '@tanstack/react-query';
 import type { TripsData } from '@type/trips';
-import { AxiosError } from 'axios';
+import type { AxiosError } from 'axios';
 
 import { getTrips } from '@api/trips/trips';
 

--- a/frontend/src/hooks/useAddTripItemForm.ts
+++ b/frontend/src/hooks/useAddTripItemForm.ts
@@ -1,9 +1,10 @@
 import type { TripItemFormType } from '@type/tripItem';
-import { FormEvent, useCallback, useState } from 'react';
+import type { FormEvent } from 'react';
+import { useCallback, useState } from 'react';
 
 import { isEmptyString } from '@utils/validator';
 
-import { useAddTripItemMutation } from './api/useAddTripItemMutation';
+import { useAddTripItemMutation } from '@hooks/api/useAddTripItemMutation';
 
 export const useAddTripItemForm = (
   tripId: number,

--- a/frontend/src/hooks/useAddTripItemForm.ts
+++ b/frontend/src/hooks/useAddTripItemForm.ts
@@ -9,9 +9,9 @@ import { useAddTripItemMutation } from '@hooks/api/useAddTripItemMutation';
 export const useAddTripItemForm = (
   tripId: number,
   initialDayLogId: number,
-  onSuccess?: CallableFunction
+  onSuccess?: () => void
 ) => {
-  const addTripItemMutation = useAddTripItemMutation(onSuccess);
+  const addTripItemMutation = useAddTripItemMutation();
   const [tripItemInformation, setTripItemInformation] = useState<TripItemFormType>({
     itemType: true,
     dayLogId: initialDayLogId,
@@ -51,7 +51,7 @@ export const useAddTripItemForm = (
       return;
     }
 
-    addTripItemMutation.mutate({ tripId, ...tripItemInformation });
+    addTripItemMutation.mutate({ tripId, ...tripItemInformation }, { onSuccess });
   };
 
   return { tripItemInformation, isTitleError, updateInputValue, disableTitleError, handleSubmit };

--- a/frontend/src/hooks/useAddTripItemForm.ts
+++ b/frontend/src/hooks/useAddTripItemForm.ts
@@ -1,0 +1,56 @@
+import { isEmptyString } from '@/utils/validator';
+import { TripItemFormType } from '@type/tripItem';
+import { FormEvent, useCallback, useState } from 'react';
+
+import { useAddTripItemMutation } from './api/useAddTripItemMutation';
+
+export const useAddTripItemForm = (
+  tripId: number,
+  initialDayLogId: number,
+  onSuccess?: CallableFunction
+) => {
+  const addTripItemMutation = useAddTripItemMutation(onSuccess);
+  const [tripItemInformation, setTripItemInformation] = useState<TripItemFormType>({
+    itemType: true,
+    dayLogId: initialDayLogId,
+    title: '',
+    place: null,
+    rating: null,
+    expense: null,
+    memo: null,
+    imageUrls: [],
+  });
+  const [isTitleError, setIsTitleError] = useState(false);
+
+  const updateInputValue = useCallback(
+    <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => {
+      setTripItemInformation((prevTripItemInformation) => {
+        const data = {
+          ...prevTripItemInformation,
+          [key]: value,
+        };
+
+        return data;
+      });
+    },
+    []
+  );
+
+  const disableTitleError = useCallback(() => {
+    setIsTitleError(false);
+  }, []);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isEmptyString(tripItemInformation.title)) {
+      setIsTitleError(true);
+
+      return;
+    }
+
+    addTripItemMutation.mutate({ tripId, ...tripItemInformation });
+  };
+
+  return { tripItemInformation, isTitleError, updateInputValue, disableTitleError, handleSubmit };
+};

--- a/frontend/src/hooks/useAddTripItemForm.ts
+++ b/frontend/src/hooks/useAddTripItemForm.ts
@@ -1,6 +1,7 @@
-import { isEmptyString } from '@/utils/validator';
 import { TripItemFormType } from '@type/tripItem';
 import { FormEvent, useCallback, useState } from 'react';
+
+import { isEmptyString } from '@utils/validator';
 
 import { useAddTripItemMutation } from './api/useAddTripItemMutation';
 

--- a/frontend/src/hooks/useAddTripItemForm.ts
+++ b/frontend/src/hooks/useAddTripItemForm.ts
@@ -1,4 +1,4 @@
-import { TripItemFormType } from '@type/tripItem';
+import type { TripItemFormType } from '@type/tripItem';
 import { FormEvent, useCallback, useState } from 'react';
 
 import { isEmptyString } from '@utils/validator';

--- a/frontend/src/hooks/useTripItemExpenseInput.ts
+++ b/frontend/src/hooks/useTripItemExpenseInput.ts
@@ -1,0 +1,56 @@
+import { DEFAULT_CURRENCY } from '@constants/trip';
+import { useQueryClient } from '@tanstack/react-query';
+import type { ExpenseCategoryData } from '@type/expense';
+import type { TripItemFormType } from '@type/tripItem';
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+
+export const useTripItemExpenseInput = (
+  updateInputValue: <K extends keyof TripItemFormType>(key: K, value: TripItemFormType[K]) => void,
+  initialExpenseValue?: TripItemFormType['expense']
+) => {
+  const [_, setExpenseValue] = useState<TripItemFormType['expense']>(
+    initialExpenseValue ?? {
+      currency: DEFAULT_CURRENCY,
+      categoryId: 100,
+      amount: 0,
+    }
+  );
+
+  const queryClient = useQueryClient();
+  const expenseCategoryData = queryClient.getQueryData<ExpenseCategoryData[]>(['expenseCategory'])!;
+
+  const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setExpenseValue((prevExpenseValue) => {
+      const newExpenseValue = { ...prevExpenseValue!, categoryId: Number(event.target.value) };
+
+      if (prevExpenseValue?.amount) updateInputValue('expense', newExpenseValue);
+
+      return newExpenseValue;
+    });
+  };
+
+  const handleCurrencyChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setExpenseValue((prevExpenseValue) => {
+      const newExpenseValue = { ...prevExpenseValue!, currency: event.target.value };
+
+      if (prevExpenseValue?.amount) updateInputValue('expense', newExpenseValue);
+
+      return newExpenseValue;
+    });
+  };
+
+  const handleAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setExpenseValue((prevExpenseValue) => {
+      const newExpenseValue = {
+        ...prevExpenseValue!,
+        amount: Number(event.target.value),
+      };
+      updateInputValue('expense', newExpenseValue.amount === 0 ? null : newExpenseValue);
+
+      return newExpenseValue;
+    });
+  };
+
+  return { expenseCategoryData, handleCategoryChange, handleCurrencyChange, handleAmountChange };
+};

--- a/frontend/src/mocks/data/expense.ts
+++ b/frontend/src/mocks/data/expense.ts
@@ -1,0 +1,26 @@
+export const expenseCategories = [
+  {
+    id: 100,
+    name: '음식',
+  },
+  {
+    id: 200,
+    name: '문화',
+  },
+  {
+    id: 300,
+    name: '쇼핑',
+  },
+  {
+    id: 400,
+    name: '숙박',
+  },
+  {
+    id: 500,
+    name: '교통',
+  },
+  {
+    id: 600,
+    name: '기타',
+  },
+];

--- a/frontend/src/mocks/data/trip.ts
+++ b/frontend/src/mocks/data/trip.ts
@@ -4,7 +4,7 @@ export const trip: TripData = {
   id: 1,
   title: '런던 여행',
   startDate: '2023-07-01',
-  endDate: '2023-07-03',
+  endDate: '2023-07-04',
   description: '라곤의 좌충우돌 유럽 여행기',
   imageUrl:
     'https://a.cdn-hotels.com/gdcs/production153/d1371/e6c1f55e-51ac-41d5-8c63-2d0c63faf59e.jpg',
@@ -66,7 +66,7 @@ export const trip: TripData = {
           id: 2,
           itemType: true,
           title: '대영박물관',
-          ordinal: 1,
+          ordinal: 2,
           rating: null,
           memo: '세계의 역사를 볼 수 있는 대영박물관',
           place: {
@@ -86,7 +86,7 @@ export const trip: TripData = {
           id: 3,
           itemType: false,
           title: '택시',
-          ordinal: 1,
+          ordinal: 3,
           rating: null,
           memo: '대영박물관에서 빅밴으로',
           place: null,
@@ -113,7 +113,7 @@ export const trip: TripData = {
           id: 5,
           itemType: true,
           title: 'LOWDOWN',
-          ordinal: 2,
+          ordinal: 1,
           rating: 4.5,
           memo: null,
           place: {
@@ -164,9 +164,16 @@ export const trip: TripData = {
     },
     {
       id: 3,
-      title: '파리 방문기',
+      title: '',
       ordinal: 3,
       date: '2023-07-03',
+      items: [],
+    },
+    {
+      id: 4,
+      title: '',
+      ordinal: 4,
+      date: '2023-07-04',
       items: [],
     },
   ],

--- a/frontend/src/mocks/data/trips.ts
+++ b/frontend/src/mocks/data/trips.ts
@@ -1,4 +1,4 @@
-export const tripsMock = [
+export const trips = [
   {
     id: 1,
     title: '런던 여행',

--- a/frontend/src/mocks/handlers/expense.ts
+++ b/frontend/src/mocks/handlers/expense.ts
@@ -1,0 +1,9 @@
+import { END_POINTS } from '@constants/api';
+import { expenseCategories } from '@mocks/data/expense';
+import { rest } from 'msw';
+
+export const expenseHandlers = [
+  rest.get(END_POINTS.EXPENSE_CATEGORY, (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(expenseCategories));
+  }),
+];

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,6 +1,13 @@
 import { cityHandlers } from '@mocks/handlers/city';
 import { dayLogHandlers } from '@mocks/handlers/dayLog';
-import { tripHandlers } from '@mocks/handlers/trip';
-import { tripsHandler } from '@mocks/handlers/trips';
+import { expenseHandlers } from '@mocks/handlers/expense';
+import { tripItemHandlers } from '@mocks/handlers/tripItem';
+import { tripsHandlers } from '@mocks/handlers/trips';
 
-export const handlers = [...cityHandlers, ...dayLogHandlers, ...tripHandlers, ...tripsHandler];
+export const handlers = [
+  ...cityHandlers,
+  ...dayLogHandlers,
+  ...expenseHandlers,
+  ...tripsHandlers,
+  ...tripItemHandlers,
+];

--- a/frontend/src/mocks/handlers/trip.ts
+++ b/frontend/src/mocks/handlers/trip.ts
@@ -1,9 +1,0 @@
-import { END_POINTS } from '@constants/api';
-import { trip } from '@mocks/data/trip';
-import { rest } from 'msw';
-
-export const tripHandlers = [
-  rest.get(`${END_POINTS.TRIPS}/:tripId`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(trip));
-  }),
-];

--- a/frontend/src/mocks/handlers/tripItem.ts
+++ b/frontend/src/mocks/handlers/tripItem.ts
@@ -11,7 +11,7 @@ export const tripItemHandlers = [
       id: 7,
       itemType: false,
       title: response.title,
-      ordinal: 4,
+      ordinal: 1,
       rating: response.rating,
       memo: response.memo,
       place: response.place,
@@ -21,15 +21,15 @@ export const tripItemHandlers = [
             currency: response.expense.currency as CurrencyType,
             amount: response.expense.amount,
             category: {
-              id: 100,
-              name: '음식',
+              id: 500,
+              name: '교통',
             },
           }
         : null,
       imageUrls: [],
     };
 
-    trip.dayLogs[0].items.push(newTripItem);
+    trip.dayLogs[2].items.push(newTripItem);
 
     return res(ctx.status(200));
   }),

--- a/frontend/src/mocks/handlers/tripItem.ts
+++ b/frontend/src/mocks/handlers/tripItem.ts
@@ -1,0 +1,37 @@
+import { trip } from '@mocks/data/trip';
+import type { CurrencyType, TripItemFormType } from '@type/tripItem';
+import { rest } from 'msw';
+
+export const tripItemHandlers = [
+  rest.post('/trips/:tripId/items', async (req, res, ctx) => {
+    const { tripId } = req.params;
+    const response = await req.json<TripItemFormType>();
+    console.log(response, '!!');
+
+    const newTripItem = {
+      id: 7,
+      itemType: false,
+      title: response.title,
+      ordinal: 4,
+      rating: response.rating,
+      memo: response.memo,
+      place: response.place,
+      expense: response.expense
+        ? {
+            id: 4,
+            currency: response.expense.currency as CurrencyType,
+            amount: response.expense.amount,
+            category: {
+              id: 100,
+              name: '음식',
+            },
+          }
+        : null,
+      imageUrls: [],
+    };
+
+    trip.dayLogs[0].items.push(newTripItem);
+
+    return res(ctx.delay(3000), ctx.status(200));
+  }),
+];

--- a/frontend/src/mocks/handlers/tripItem.ts
+++ b/frontend/src/mocks/handlers/tripItem.ts
@@ -6,7 +6,6 @@ export const tripItemHandlers = [
   rest.post('/trips/:tripId/items', async (req, res, ctx) => {
     const { tripId } = req.params;
     const response = await req.json<TripItemFormType>();
-    console.log(response, '!!');
 
     const newTripItem = {
       id: 7,
@@ -32,6 +31,6 @@ export const tripItemHandlers = [
 
     trip.dayLogs[0].items.push(newTripItem);
 
-    return res(ctx.delay(3000), ctx.status(200));
+    return res(ctx.status(200));
   }),
 ];

--- a/frontend/src/mocks/handlers/trips.ts
+++ b/frontend/src/mocks/handlers/trips.ts
@@ -1,3 +1,5 @@
+import { END_POINTS } from '@constants/api';
+import { trip } from '@mocks/data/trip';
 import { tripsMock } from '@mocks/data/trips';
 import { rest } from 'msw';
 
@@ -10,12 +12,17 @@ export const tripsHandler = [
       })
     );
   }),
-  rest.get('/trips/none', (req, res, ctx) => {
+
+  rest.get(`${END_POINTS.TRIPS}/none`, (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
         trips: [],
       })
     );
+  }),
+
+  rest.get(`${END_POINTS.TRIPS}/:tripId`, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(trip));
   }),
 ];

--- a/frontend/src/mocks/handlers/trips.ts
+++ b/frontend/src/mocks/handlers/trips.ts
@@ -3,7 +3,7 @@ import { trip } from '@mocks/data/trip';
 import { tripsMock } from '@mocks/data/trips';
 import { rest } from 'msw';
 
-export const tripsHandler = [
+export const tripsHandlers = [
   rest.get('/trips', (req, res, ctx) => {
     return res(
       ctx.status(200),

--- a/frontend/src/mocks/handlers/trips.ts
+++ b/frontend/src/mocks/handlers/trips.ts
@@ -1,6 +1,6 @@
 import { END_POINTS } from '@constants/api';
 import { trip } from '@mocks/data/trip';
-import { tripsMock } from '@mocks/data/trips';
+import { trips } from '@mocks/data/trips';
 import { rest } from 'msw';
 
 export const tripsHandlers = [
@@ -8,7 +8,7 @@ export const tripsHandlers = [
     return res(
       ctx.status(200),
       ctx.json({
-        trips: tripsMock,
+        trips,
       })
     );
   }),

--- a/frontend/src/pages/TripEditPage/TripEditPage.tsx
+++ b/frontend/src/pages/TripEditPage/TripEditPage.tsx
@@ -19,8 +19,10 @@ const TripEditPage = () => {
   useExpenseCategoryQuery();
 
   const { isOpen, open, close } = useOverlay();
-  const { selected, handleSelectClick } = useSelect(tripData.dayLogs[0].id);
-  const selectedDayLog = tripData.dayLogs.find((log) => log.id === selected)!;
+  const { selected: selectedDayLogId, handleSelectClick: handleDayLogIdSelectClick } = useSelect(
+    tripData.dayLogs[0].id
+  );
+  const selectedDayLog = tripData.dayLogs.find((log) => log.id === selectedDayLogId)!;
 
   const dates = tripData.dayLogs.map((data) => ({
     id: data.id,
@@ -34,7 +36,7 @@ const TripEditPage = () => {
         tripId={Number(tripId)}
         selectedDayLog={selectedDayLog}
         dates={dates}
-        onTabChange={handleSelectClick}
+        onTabChange={handleDayLogIdSelectClick}
       />
       <FloatingButton css={addButtonStyling} onClick={open} />
       <TripItemAddModal

--- a/frontend/src/pages/TripEditPage/TripEditPage.tsx
+++ b/frontend/src/pages/TripEditPage/TripEditPage.tsx
@@ -18,7 +18,7 @@ const TripEditPage = () => {
   const { tripData } = useTripQuery(Number(tripId));
   useExpenseCategoryQuery();
 
-  const { isOpen, open, close } = useOverlay();
+  const { isOpen: isAddModalOpen, open: openAddModal, close: closeAddModal } = useOverlay();
   const { selected: selectedDayLogId, handleSelectClick: handleDayLogIdSelectClick } = useSelect(
     tripData.dayLogs[0].id
   );
@@ -38,13 +38,13 @@ const TripEditPage = () => {
         dates={dates}
         onTabChange={handleDayLogIdSelectClick}
       />
-      <FloatingButton css={addButtonStyling} onClick={open} />
+      <FloatingButton css={addButtonStyling} onClick={openAddModal} />
       <TripItemAddModal
         tripId={Number(tripId)}
-        isOpen={isOpen}
+        isOpen={isAddModalOpen}
         dates={dates}
         currentDate={{ id: selectedDayLog.id, date: selectedDayLog.date }}
-        onClose={close}
+        onClose={closeAddModal}
       />
     </section>
   );

--- a/frontend/src/pages/TripEditPage/TripEditPage.tsx
+++ b/frontend/src/pages/TripEditPage/TripEditPage.tsx
@@ -37,6 +37,7 @@ const TripEditPage = () => {
         selectedDayLog={selectedDayLog}
         dates={dates}
         onTabChange={handleDayLogIdSelectClick}
+        openAddModal={openAddModal}
       />
       <FloatingButton css={addButtonStyling} onClick={openAddModal} />
       <TripItemAddModal

--- a/frontend/src/pages/TripEditPage/TripEditPage.tsx
+++ b/frontend/src/pages/TripEditPage/TripEditPage.tsx
@@ -1,12 +1,14 @@
-import { FloatingButton } from 'hang-log-design-system';
+import { FloatingButton, useOverlay, useSelect } from 'hang-log-design-system';
 import { useParams } from 'react-router-dom';
 
+import { useExpenseCategoryQuery } from '@hooks/api/useExpenseCategoryQuery';
 import { useTripQuery } from '@hooks/api/useTripQuery';
 
 import { addButtonStyling, containerStyling } from '@pages/TripEditPage/TripEditPage.style';
 
 import DayLogList from '@components/common/DayLogList/DayLogList';
 import TripInformation from '@components/common/TripInformation/TripInformation';
+import TripItemAddModal from '@components/trip/TripItemAddModal/TripItemAddModal';
 
 const TripEditPage = () => {
   const { tripId } = useParams();
@@ -14,12 +16,34 @@ const TripEditPage = () => {
   if (!tripId) throw new Error(`tripId doesn't exist`);
 
   const { tripData } = useTripQuery(Number(tripId));
+  useExpenseCategoryQuery();
+
+  const { isOpen, open, close } = useOverlay();
+  const { selected, handleSelectClick } = useSelect(tripData.dayLogs[0].id);
+  const selectedDayLog = tripData.dayLogs.find((log) => log.id === selected)!;
+
+  const dates = tripData.dayLogs.map((data) => ({
+    id: data.id,
+    date: data.date,
+  }));
 
   return (
     <section css={containerStyling}>
       <TripInformation {...tripData} />
-      <DayLogList tripId={Number(tripId)} logs={tripData.dayLogs} />
-      <FloatingButton css={addButtonStyling} />
+      <DayLogList
+        tripId={Number(tripId)}
+        selectedDayLog={selectedDayLog}
+        dates={dates}
+        onTabChange={handleSelectClick}
+      />
+      <FloatingButton css={addButtonStyling} onClick={open} />
+      <TripItemAddModal
+        tripId={Number(tripId)}
+        isOpen={isOpen}
+        dates={dates}
+        currentDate={{ id: selectedDayLog.id, date: selectedDayLog.date }}
+        onClose={close}
+      />
     </section>
   );
 };

--- a/frontend/src/stories/common/DayLogList.stories.tsx
+++ b/frontend/src/stories/common/DayLogList.stories.tsx
@@ -1,5 +1,6 @@
 import { trip } from '@mocks/data/trip';
 import type { Meta, StoryObj } from '@storybook/react';
+import { useSelect } from 'hang-log-design-system';
 
 import DayLogList from '@components/common/DayLogList/DayLogList';
 
@@ -8,14 +9,37 @@ const meta = {
   component: DayLogList,
   argTypes: {
     tripId: { control: false },
-  },
-  args: {
-    tripId: 1,
-    logs: [...trip.dayLogs],
+    selectedDayLog: { control: false },
+    dates: { control: false },
   },
 } satisfies Meta<typeof DayLogList>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: ({ ...args }) => {
+    const { selected, handleSelectClick } = useSelect(trip.dayLogs[0].id);
+    const selectedDayLog = trip.dayLogs.find((log) => log.id === selected)!;
+
+    const dates = trip.dayLogs.map((data) => ({
+      id: data.id,
+      date: data.date,
+    }));
+
+    return (
+      <DayLogList
+        tripId={1}
+        selectedDayLog={selectedDayLog}
+        dates={dates}
+        onTabChange={handleSelectClick}
+      />
+    );
+  },
+  args: {
+    tripId: 1,
+    selectedDayLog: trip.dayLogs[0],
+    dates: [],
+    onTabChange: () => {},
+  },
+};

--- a/frontend/src/stories/common/DayLogList.stories.tsx
+++ b/frontend/src/stories/common/DayLogList.stories.tsx
@@ -33,6 +33,7 @@ export const Default: Story = {
         selectedDayLog={selectedDayLog}
         dates={dates}
         onTabChange={handleSelectClick}
+        openAddModal={() => {}}
       />
     );
   },

--- a/frontend/src/stories/common/TripsItemList.stories.tsx
+++ b/frontend/src/stories/common/TripsItemList.stories.tsx
@@ -1,4 +1,4 @@
-import { tripsMock } from '@mocks/data/trips';
+import { trips } from '@mocks/data/trips';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { sortByStartDate } from '@utils/sortByStartDate';
@@ -9,7 +9,7 @@ const meta = {
   title: 'common/TripsItemList',
   component: TripsItemList,
   args: {
-    trips: tripsMock,
+    trips: trips,
     order: '등록순',
     changeSelect: (selectedId: string | number) => {},
   },
@@ -19,11 +19,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const SortBy_Register: Story = {};
+
 export const SortBy_Date: Story = {
   render: () => {
     return (
       <TripsItemList
-        trips={tripsMock?.slice().sort(sortByStartDate)}
+        trips={trips?.slice().sort(sortByStartDate)}
         order="날짜순"
         changeSelect={(selectedId: string | number) => {}}
       />

--- a/frontend/src/types/expense.ts
+++ b/frontend/src/types/expense.ts
@@ -1,0 +1,4 @@
+export interface ExpenseCategoryData {
+  id: number;
+  name: string;
+}

--- a/frontend/src/types/tripItem.ts
+++ b/frontend/src/types/tripItem.ts
@@ -1,6 +1,8 @@
 import { CURRENCY_ICON } from '@constants/trip';
 
-type Currency = keyof typeof CURRENCY_ICON;
+export type CurrencyType = keyof typeof CURRENCY_ICON;
+
+export type StarRatingData = 0 | 0.5 | 1 | 1.5 | 2 | 2.5 | 3 | 3.5 | 4 | 4.5 | 5;
 
 interface PlaceData {
   id: number;
@@ -15,7 +17,7 @@ interface PlaceData {
 
 interface ExpenseData {
   id: number;
-  currency: Currency;
+  currency: CurrencyType;
   amount: number;
   category: {
     id: number;
@@ -28,9 +30,26 @@ export interface TripItemData {
   itemType: boolean;
   title: string;
   ordinal: number;
-  rating: 0 | 0.5 | 1 | 1.5 | 2 | 2.5 | 3 | 3.5 | 4 | 4.5 | 5 | null;
+  rating: StarRatingData | null;
   memo: string | null;
   place: PlaceData | null;
   expense: ExpenseData | null;
+  imageUrls: string[];
+}
+
+export type TripItemCategory = '장소' | '기타';
+
+export interface TripItemFormType {
+  itemType: boolean;
+  dayLogId: number | null;
+  title: string;
+  place: PlaceData | null;
+  rating: StarRatingData | null;
+  expense: {
+    currency: string;
+    amount: number;
+    categoryId: number;
+  } | null;
+  memo: string | null;
   imageUrls: string[];
 }

--- a/frontend/src/utils/formatter.ts
+++ b/frontend/src/utils/formatter.ts
@@ -6,6 +6,6 @@ export const formatMonthDate = (date: string) => {
   return formatDate(date).slice(5);
 };
 
-export const moneyFormatter = (money: number) => {
-  return money === 0 ? 0 : money.toLocaleString();
+export const formatNumberToMoney = (number: number) => {
+  return number === 0 ? 0 : number.toLocaleString();
 };

--- a/frontend/src/utils/validator.ts
+++ b/frontend/src/utils/validator.ts
@@ -1,0 +1,3 @@
+export const isEmptyString = (input: string) => {
+  return /^$/.test(input);
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "target": "ES5",
+    "target": "ES2015",
     "skipLibCheck": true,
     "module": "commonjs",
     "strict": true,


### PR DESCRIPTION
## 📄 Summary

<img width="1512" alt="Trip Item Add Modal - non spot-1" src="https://github.com/woowacourse-teams/2023-hang-log/assets/51967731/c4dbcbc3-5946-4851-a745-f06138aba3ce">

<br>

TripItem 추가 모달 일부 구현

<br>

- [x] 카테고리, 날짜, 제목을 필수로 입력해야 한다. 
  - [x] 날짜는 모달 생성을 클릭한 탭의 날짜가 디폴트로 설정된다.
  - [ ] 카테고리 `장소` 선택 시 제목은 구글 map api를 사용해서 검색 결과 확인 및 자동완성을 할 수 있다. 
  - [x] 카테코리 `기타` 선택 시 제목은 사용자가 입력한 값이 된다. 
- [x] 옵셔널로는 별점, 비용 (카테고리, 통화, 금액), 메모, 사진을 입력할 수 있다. 
  - [x] 비용 카테고리 디폴트는 `음식`, 통화 디폴트는 `₩(원)`이다. 
- [ ] 사진은 최대 5장 업로드할 수 있다. 
- [ ] 일정 추가/수정 성공 시 성공했다는 토스트 메세지를 볼 수 있다. 



## 🙋🏻 More
TripItem 추가 모달 일부 구현했습니다! 

위에서 체크 안 된 부분들은 코드량이 많아질 것 같아서 새로 이슈 파서 작업하겠습니다. 

현재 `기타` 카테고리에 대해서만 입력 추가할 수 있습니다. 
제목이 입력되지 않은 경우에는 에러 메세지가 뜹니다. 추가하면 Day 1 목록 밑에 추가되는 것을 볼 수 있습니다. 

close #52 
