### PR TITLE
초 기본적인 로깅 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -44,3 +44,5 @@ src/main/resources/static/docs/
 
 ### Ignore .DS_Store ###
 **/.DS_Store
+
+log/

--- a/backend/src/main/java/hanglog/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/hanglog/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package hanglog.global.exception;
 
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -9,28 +12,34 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.util.Objects;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    // TODO: Logger 달기
+    private static final Logger handlerLogger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(final MethodArgumentNotValidException ex, final HttpHeaders headers, final HttpStatusCode status, final WebRequest request) {
-        final String errMessage = Objects.requireNonNull(ex.getBindingResult().getFieldError()).getDefaultMessage();
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            final MethodArgumentNotValidException e,
+            final HttpHeaders headers,
+            final HttpStatusCode status,
+            final WebRequest request
+    ) {
+        final String errMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
+        handlerLogger.warn(errMessage, e);
         return ResponseEntity.badRequest()
                 .body(new ExceptionResponse(0000, errMessage));
     }
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ExceptionResponse> handleBadRequestException(final BadRequestException e) {
+        handlerLogger.warn(e.getMessage(), e);
         return ResponseEntity.badRequest()
                 .body(new ExceptionResponse(e.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
+        handlerLogger.error(e.getMessage(), e);
         return ResponseEntity.internalServerError()
                 .body(new ExceptionResponse(9999, e.getMessage()));
     }

--- a/backend/src/main/java/hanglog/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/hanglog/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,7 @@
 package hanglog.global.exception;
 
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -13,9 +12,8 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
-
-    private static final Logger handlerLogger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
@@ -25,21 +23,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             final WebRequest request
     ) {
         final String errMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
-        handlerLogger.warn(errMessage, e);
+        log.warn(errMessage, e);
         return ResponseEntity.badRequest()
                 .body(new ExceptionResponse(0000, errMessage));
     }
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ExceptionResponse> handleBadRequestException(final BadRequestException e) {
-        handlerLogger.warn(e.getMessage(), e);
+        log.warn(e.getMessage(), e);
         return ResponseEntity.badRequest()
                 .body(new ExceptionResponse(e.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
-        handlerLogger.error(e.getMessage(), e);
+        log.error(e.getMessage(), e);
         return ResponseEntity.internalServerError()
                 .body(new ExceptionResponse(9999, e.getMessage()));
     }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="true">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+
+    <springProperty scope="context" name="LOG_DIR" source="logging.directory"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/error/error-${BY_DATE}.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/warn/warn-${BY_DATE}.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="FILE-ERROR"/>
+        <appender-ref ref="FILE-WARN"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -14,7 +14,7 @@
     </appender>
 
     <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_DIR}/error/error-${BY_DATE}.log</file>
+        <file>${LOG_DIR}/error/${BY_DATE}.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <onMatch>ACCEPT</onMatch>
@@ -33,7 +33,7 @@
     </appender>
 
     <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_DIR}/warn/warn-${BY_DATE}.log</file>
+        <file>${LOG_DIR}/warn/${BY_DATE}.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>
             <onMatch>ACCEPT</onMatch>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -25,7 +25,7 @@
             <charset>utf8</charset>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_DIR}/backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>${LOG_DIR}/backup/error/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
             <maxHistory>10</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
@@ -44,7 +44,7 @@
             <charset>utf8</charset>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_DIR}/backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>${LOG_DIR}/backup/warn/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
             <maxHistory>10</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>


### PR DESCRIPTION
## 📄 Summary
> #115 

초초 기본적인 로깅 파일 생성 로직 구현해 놨습니다.
 - #### warn과 error 레벨의 로그만 파일에 기록
 - #### 위치: backend/log 디렉토리에 warn과 error 디렉토리 만들어지고 거기에 각각 파일 생성됨
 - #### 파일 네이밍: warn-2023-07-29.log 형식으로 파일 생성
 - #### 용량 제한: 각 파일당 100MB, 디렉토리 당 총 파일 개수는 10개 제한 (파일이 10개일 경우 가장 오래된 파일 삭제)

## 🙋🏻 More
> 저희가 현재 hanglog-dev 에 백엔드 코드 , nginx, 사진 파일까지 올라가고 있는 상황이라 로그 파일의 용량 제한을 warn, error 각각 1GB, 총 2GB로 빡세게 제한을 걸어 놨습니다. 각각 어느정도로 용량을 할당해야 할 지 논의가 필요할 듯 합니다.  ~역시 사진은 S3로 옮기는게..~
