### PR TITLE
fix: webpack config에서 process.env.NODE_ENV를 읽어오지 못하는 문제 해결 시도

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "NODE_ENV=development webpack --mode development",
     "dev": "NODE_ENV=development webpack serve --mode development --open --hot",
-    "build": "NODE_ENV=production webpack",
+    "build": "NODE_ENV=production webpack --mode production",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint": "eslint src"


### PR DESCRIPTION
## 📄 Summary
> --mode production이 빠졌는데, 그건 둘째치고 bundle.js를 안불러옵니다...

## 🙋🏻 More
>
