### PR TITLE
여행 처음 생성 후 소제목 입력시 모든 day log 탭에서 같은 소제목 보이는 문제 해결

### DIFF
--- a/frontend/src/components/common/DayLogItem/TitleInput/TitleInput.tsx
+++ b/frontend/src/components/common/DayLogItem/TitleInput/TitleInput.tsx
@@ -19,7 +19,7 @@ const TitleInput = ({ tripId, dayLogId, initialTitle }: TitleInputProps) => {
 
   useEffect(() => {
     setTitle(initialTitle);
-  }, [initialTitle]);
+  }, [initialTitle, dayLogId]);
 
   const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);

--- a/frontend/src/hooks/api/useDayLogTitleMutation.ts
+++ b/frontend/src/hooks/api/useDayLogTitleMutation.ts
@@ -1,9 +1,15 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { patchDayLogTitle } from '@api/dayLog/patchDayLogTitle';
 
 export const useDayLogTitleMutation = () => {
-  const dayLogTitleMutation = useMutation(patchDayLogTitle());
+  const queryClient = useQueryClient();
+
+  const dayLogTitleMutation = useMutation(patchDayLogTitle(), {
+    onSuccess: (_, { tripId }) => {
+      queryClient.invalidateQueries(['trip', tripId]);
+    },
+  });
 
   return dayLogTitleMutation;
 };

--- a/frontend/src/stories/trips/TripsItem.stories.tsx
+++ b/frontend/src/stories/trips/TripsItem.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
   title: 'trips/TripsItem',
   component: TripsItem,
   args: {
+    id: 1,
     index: 0,
     itemName: trips[0].title,
     cityTags: trips[0].cities,


### PR DESCRIPTION
## 📄 Summary
여행 처음 생성 후 소제목 작성하면 다른 데이로그 탭에서도 같은 소제목이는 문제 해결

## 🙋🏻 More
close #257 
