### PR TITLE
아이템 수정할 때 기타에서 장소로 변경할 때 에러 보여주기

### DIFF
--- a/frontend/src/hooks/trip/useAddTripItemForm.ts
+++ b/frontend/src/hooks/trip/useAddTripItemForm.ts
@@ -61,6 +61,14 @@ export const useAddTripItemForm = ({
 
     if (
       tripItemInformation.itemType &&
+      tripItemInformation.isPlaceUpdated === false &&
+      initialData?.itemType === false
+    ) {
+      return true;
+    }
+
+    if (
+      tripItemInformation.itemType &&
       !tripItemInformation.place &&
       tripItemInformation.isPlaceUpdated === undefined
     ) {


### PR DESCRIPTION
## 📄 Summary
- 아이템 수정할 때 기타에서 장소로 변경할 때 에러 보여주기 -> 기존에는 변경해도 아무 문제 없었다

## 🙋🏻 More
close #290 
