### PR TITLE
Item Spot과 Nonspot간 변환시 Place 설정 추가

### DIFF
--- a/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
@@ -24,7 +24,8 @@ public enum ExceptionCode {
 
     INVALID_RATING(3001, "별점은 N.0점이거나 N.5점 형태이어야 합니다."),
     INVALID_CURRENCY(3002, "제공하지 않는 통화입니다."),
-    INVALID_NULL_PLACE(3003, "아이템의 장소 정보가 필요합니다."),
+    INVALID_NULL_PLACE(3003, "아이템 타입이 장소일 경우, 아이템의 장소 정보가 필요합니다."),
+    INVALID_PLACE(3004, "아이템 타입이 기타일 경우,아이템의 장소 정보가 불필요합니다."),
 
     INVALID_ORDERED_ITEM_IDS(4001, "날짜에 속한 모든 여행 아이템들의 ID가 필요합니다."),
 

--- a/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
@@ -24,6 +24,7 @@ public enum ExceptionCode {
 
     INVALID_RATING(3001, "별점은 N.0점이거나 N.5점 형태이어야 합니다."),
     INVALID_CURRENCY(3002, "제공하지 않는 통화입니다."),
+    INVALID_NULL_PLACE(3003, "아이템의 장소 정보가 필요합니다."),
 
     INVALID_ORDERED_ITEM_IDS(4001, "날짜에 속한 모든 여행 아이템들의 ID가 필요합니다."),
 

--- a/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
@@ -25,7 +25,8 @@ public enum ExceptionCode {
     INVALID_RATING(3001, "별점은 N.0점이거나 N.5점 형태이어야 합니다."),
     INVALID_CURRENCY(3002, "제공하지 않는 통화입니다."),
     INVALID_NULL_PLACE(3003, "아이템의 장소 정보가 필요합니다."),
-    INVALID_PLACE(3004, "아이템의 장소 정보가 불필요합니다."),
+    INVALID_NOT_NULL_PLACE(3004, "아이템의 장소 정보가 불필요합니다."),
+    INVALID_IS_PLACE_UPDATED_WHEN_NON_SPOT(3005, "아이템이 기타일 때, 장소를 업데이트할 수 없습니다."),
 
     INVALID_ORDERED_ITEM_IDS(4001, "날짜에 속한 모든 여행 아이템들의 ID가 필요합니다."),
 

--- a/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/hanglog/global/exception/ExceptionCode.java
@@ -24,8 +24,8 @@ public enum ExceptionCode {
 
     INVALID_RATING(3001, "별점은 N.0점이거나 N.5점 형태이어야 합니다."),
     INVALID_CURRENCY(3002, "제공하지 않는 통화입니다."),
-    INVALID_NULL_PLACE(3003, "아이템 타입이 장소일 경우, 아이템의 장소 정보가 필요합니다."),
-    INVALID_PLACE(3004, "아이템 타입이 기타일 경우,아이템의 장소 정보가 불필요합니다."),
+    INVALID_NULL_PLACE(3003, "아이템의 장소 정보가 필요합니다."),
+    INVALID_PLACE(3004, "아이템의 장소 정보가 불필요합니다."),
 
     INVALID_ORDERED_ITEM_IDS(4001, "날짜에 속한 모든 여행 아이템들의 ID가 필요합니다."),
 

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
@@ -1,5 +1,6 @@
 package hanglog.trip.dto.request;
 
+import static hanglog.global.exception.ExceptionCode.INVALID_NULL_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 
 import hanglog.global.exception.BadRequestException;
@@ -48,6 +49,7 @@ public class ItemRequest {
             final List<String> imageUrls,
             final PlaceRequest place, final ExpenseRequest expense
     ) {
+        validateExistPlaceWhenSpot(itemType, place);
         validateRatingFormat(rating);
         this.itemType = itemType;
         this.title = title;
@@ -65,7 +67,13 @@ public class ItemRequest {
         }
     }
 
-    private boolean isInvalidRatingFormat(Double rating) {
+    private boolean isInvalidRatingFormat(final Double rating) {
         return rating % RATING_DECIMAL_UNIT != 0;
+    }
+
+    private void validateExistPlaceWhenSpot(final Boolean itemType, final PlaceRequest place) {
+        if (itemType && place == null) {
+            throw new BadRequestException(INVALID_NULL_PLACE);
+        }
     }
 }

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
@@ -1,7 +1,7 @@
 package hanglog.trip.dto.request;
 
+import static hanglog.global.exception.ExceptionCode.INVALID_NOT_NULL_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_NULL_PLACE;
-import static hanglog.global.exception.ExceptionCode.INVALID_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 
 import hanglog.global.exception.BadRequestException;
@@ -71,7 +71,7 @@ public class ItemRequest {
 
     private void validateNoExistPlaceWhenNonSpot(final Boolean itemType, final PlaceRequest place) {
         if (!itemType && place != null) {
-            throw new BadRequestException(INVALID_PLACE);
+            throw new BadRequestException(INVALID_NOT_NULL_PLACE);
         }
     }
 

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
@@ -1,6 +1,7 @@
 package hanglog.trip.dto.request;
 
 import static hanglog.global.exception.ExceptionCode.INVALID_NULL_PLACE;
+import static hanglog.global.exception.ExceptionCode.INVALID_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 
 import hanglog.global.exception.BadRequestException;
@@ -50,6 +51,7 @@ public class ItemRequest {
             final PlaceRequest place, final ExpenseRequest expense
     ) {
         validateExistPlaceWhenSpot(itemType, place);
+        validateNoExistPlaceWhenNonSpot(itemType, place);
         validateRatingFormat(rating);
         this.itemType = itemType;
         this.title = title;
@@ -61,6 +63,18 @@ public class ItemRequest {
         this.expense = expense;
     }
 
+    private void validateExistPlaceWhenSpot(final Boolean itemType, final PlaceRequest place) {
+        if (itemType && place == null) {
+            throw new BadRequestException(INVALID_NULL_PLACE);
+        }
+    }
+
+    private void validateNoExistPlaceWhenNonSpot(final Boolean itemType, final PlaceRequest place) {
+        if (!itemType && place != null) {
+            throw new BadRequestException(INVALID_PLACE);
+        }
+    }
+
     private void validateRatingFormat(final Double rating) {
         if (rating != null && isInvalidRatingFormat(rating)) {
             throw new BadRequestException(INVALID_RATING);
@@ -69,11 +83,5 @@ public class ItemRequest {
 
     private boolean isInvalidRatingFormat(final Double rating) {
         return rating % RATING_DECIMAL_UNIT != 0;
-    }
-
-    private void validateExistPlaceWhenSpot(final Boolean itemType, final PlaceRequest place) {
-        if (itemType && place == null) {
-            throw new BadRequestException(INVALID_NULL_PLACE);
-        }
     }
 }

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
@@ -54,7 +54,7 @@ public class ItemUpdateRequest {
             final PlaceRequest place,
             final ExpenseRequest expense
     ) {
-        validateExistPlaceWhenSpot(itemType, place);
+        validateExistPlaceWhenSpotAndPlaceUpdated(itemType, place, isPlaceUpdated);
         validateNoExistPlaceWhenNonSpot(itemType, place);
         validateRatingFormat(rating);
         this.itemType = itemType;
@@ -68,8 +68,12 @@ public class ItemUpdateRequest {
         this.expense = expense;
     }
 
-    private void validateExistPlaceWhenSpot(final Boolean itemType, final PlaceRequest place) {
-        if (itemType && place == null) {
+    private void validateExistPlaceWhenSpotAndPlaceUpdated(
+            final Boolean itemType,
+            final PlaceRequest place,
+            final Boolean isPlaceUpdated
+    ) {
+        if (itemType && isPlaceUpdated && place == null) {
             throw new BadRequestException(INVALID_NULL_PLACE);
         }
     }

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
@@ -1,5 +1,6 @@
 package hanglog.trip.dto.request;
 
+import static hanglog.global.exception.ExceptionCode.INVALID_NULL_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 
 import hanglog.global.exception.BadRequestException;
@@ -14,7 +15,7 @@ import lombok.Getter;
 public class ItemUpdateRequest {
 
     private static final double RATING_DECIMAL_UNIT = 0.5;
-    
+
     @NotNull(message = "여행 아이템의 타입을 입력해주세요.")
     private final Boolean itemType;
 
@@ -52,6 +53,7 @@ public class ItemUpdateRequest {
             final PlaceRequest place,
             final ExpenseRequest expense
     ) {
+        validateExistPlaceWhenSpot(itemType, place);
         validateRatingFormat(rating);
         this.itemType = itemType;
         this.title = title;
@@ -72,5 +74,11 @@ public class ItemUpdateRequest {
 
     private boolean isInvalidRatingFormat(final Double rating) {
         return rating % RATING_DECIMAL_UNIT != 0;
+    }
+    
+    private void validateExistPlaceWhenSpot(final Boolean itemType, final PlaceRequest place) {
+        if (itemType && place == null) {
+            throw new BadRequestException(INVALID_NULL_PLACE);
+        }
     }
 }

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
@@ -1,7 +1,8 @@
 package hanglog.trip.dto.request;
 
+import static hanglog.global.exception.ExceptionCode.INVALID_IS_PLACE_UPDATED_WHEN_NON_SPOT;
+import static hanglog.global.exception.ExceptionCode.INVALID_NOT_NULL_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_NULL_PLACE;
-import static hanglog.global.exception.ExceptionCode.INVALID_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 
 import hanglog.global.exception.BadRequestException;
@@ -54,8 +55,9 @@ public class ItemUpdateRequest {
             final PlaceRequest place,
             final ExpenseRequest expense
     ) {
-        validateExistPlaceWhenSpotAndPlaceUpdated(itemType, place, isPlaceUpdated);
-        validateNoExistPlaceWhenNonSpot(itemType, place);
+        validatePlaceWhenSpotAndPlaceUpdated(itemType, place, isPlaceUpdated);
+        validatePlaceWhenNonSpot(itemType, place);
+        validateIsPlaceUpdatedWhenNonSpot(itemType, isPlaceUpdated);
         validateRatingFormat(rating);
         this.itemType = itemType;
         this.title = title;
@@ -68,7 +70,7 @@ public class ItemUpdateRequest {
         this.expense = expense;
     }
 
-    private void validateExistPlaceWhenSpotAndPlaceUpdated(
+    private void validatePlaceWhenSpotAndPlaceUpdated(
             final Boolean itemType,
             final PlaceRequest place,
             final Boolean isPlaceUpdated
@@ -78,9 +80,15 @@ public class ItemUpdateRequest {
         }
     }
 
-    private void validateNoExistPlaceWhenNonSpot(final Boolean itemType, final PlaceRequest place) {
+    private void validatePlaceWhenNonSpot(final Boolean itemType, final PlaceRequest place) {
         if (!itemType && place != null) {
-            throw new BadRequestException(INVALID_PLACE);
+            throw new BadRequestException(INVALID_NOT_NULL_PLACE);
+        }
+    }
+
+    private void validateIsPlaceUpdatedWhenNonSpot(final Boolean itemType, final Boolean isPlaceUpdated) {
+        if (!itemType && isPlaceUpdated) {
+            throw new BadRequestException(INVALID_IS_PLACE_UPDATED_WHEN_NON_SPOT);
         }
     }
 

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemUpdateRequest.java
@@ -1,6 +1,7 @@
 package hanglog.trip.dto.request;
 
 import static hanglog.global.exception.ExceptionCode.INVALID_NULL_PLACE;
+import static hanglog.global.exception.ExceptionCode.INVALID_PLACE;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 
 import hanglog.global.exception.BadRequestException;
@@ -54,6 +55,7 @@ public class ItemUpdateRequest {
             final ExpenseRequest expense
     ) {
         validateExistPlaceWhenSpot(itemType, place);
+        validateNoExistPlaceWhenNonSpot(itemType, place);
         validateRatingFormat(rating);
         this.itemType = itemType;
         this.title = title;
@@ -66,6 +68,18 @@ public class ItemUpdateRequest {
         this.expense = expense;
     }
 
+    private void validateExistPlaceWhenSpot(final Boolean itemType, final PlaceRequest place) {
+        if (itemType && place == null) {
+            throw new BadRequestException(INVALID_NULL_PLACE);
+        }
+    }
+
+    private void validateNoExistPlaceWhenNonSpot(final Boolean itemType, final PlaceRequest place) {
+        if (!itemType && place != null) {
+            throw new BadRequestException(INVALID_PLACE);
+        }
+    }
+
     private void validateRatingFormat(final Double rating) {
         if (rating != null && isInvalidRatingFormat(rating)) {
             throw new BadRequestException(INVALID_RATING);
@@ -74,11 +88,5 @@ public class ItemUpdateRequest {
 
     private boolean isInvalidRatingFormat(final Double rating) {
         return rating % RATING_DECIMAL_UNIT != 0;
-    }
-    
-    private void validateExistPlaceWhenSpot(final Boolean itemType, final PlaceRequest place) {
-        if (itemType && place == null) {
-            throw new BadRequestException(INVALID_NULL_PLACE);
-        }
     }
 }

--- a/backend/src/main/java/hanglog/trip/service/ItemService.java
+++ b/backend/src/main/java/hanglog/trip/service/ItemService.java
@@ -82,8 +82,12 @@ public class ItemService {
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_TRIP_ITEM_ID));
 
         Place updatedPlace = item.getPlace();
-        if (itemUpdateRequest.getIsPlaceUpdated()) {
+        if (itemUpdateRequest.getIsPlaceUpdated() || isChangedToSpot(itemUpdateRequest, item)) {
             updatedPlace = makePlace(itemUpdateRequest.getPlace());
+        }
+
+        if (item.getItemType() == ItemType.SPOT && !itemUpdateRequest.getItemType()) {
+            updatedPlace = null;
         }
 
         final Item updatedItem = new Item(
@@ -100,6 +104,10 @@ public class ItemService {
         );
 
         itemRepository.save(updatedItem);
+    }
+
+    private boolean isChangedToSpot(final ItemUpdateRequest itemUpdateRequest, final Item item) {
+        return item.getItemType().equals(ItemType.NON_SPOT) && itemUpdateRequest.getPlace() != null;
     }
 
     private Place makePlace(final PlaceRequest placeRequest) {


### PR DESCRIPTION
## 📄 Summary
> #253 

* nonspot -> spot시 place 정보가 저장되게 변경
* spot -> nonspot시 place 정보가 삭제되게 변경
* 아이템 생성 request에서 ItemType이 true일 때, place가 null이라면 예외 발생
* 아이템 수정 request에서 ItemType이 true이고 isPlaceUpdated가 true일 때, place가 null이라면 예외 발생
* 아이템 수정 request에서 ItemType이 false일 때, place가 not null이라면 예외 발생
* 아이템 수정 request에서 ItemType이 false일 때, isPlaceUpdated가 true라면 예외 발생
## 🙋🏻 More
>흐에에엥 죄송합니다아ㅏ아아아아ㅏ
테스트는 작성중...
