### PR TITLE
fix: TripCreatePage에서 폼이 Header 위로 올라가는 문제 해결

### DIFF
--- a/frontend/src/pages/TripCreatePage/TripCreatePage.style.ts
+++ b/frontend/src/pages/TripCreatePage/TripCreatePage.style.ts
@@ -14,8 +14,6 @@ export const boxStyling = css({
   gap: Theme.spacer.spacing5,
 
   paddingTop: '72px',
-
-  zIndex: Theme.zIndex.overlayMiddle,
 });
 
 export const backgroundImage = css({


### PR DESCRIPTION
## 📄 Summary
<img width="933" alt="Screenshot 2023-08-03 at 3 13 11 PM" src="https://github.com/woowacourse-teams/2023-hang-log/assets/51967731/caed1b95-cbdb-43d9-b4b8-a66cc069e2f1">


## 🙋🏻 More
close #292 
