### PR TITLE
가계부 페이지 경비 없을 때 파이 차트에 100% 보이는 버그 수정

### DIFF
--- a/frontend/src/components/common/DonutChart/DonutChart.tsx
+++ b/frontend/src/components/common/DonutChart/DonutChart.tsx
@@ -49,7 +49,7 @@ const DonutChart = ({ segments, size, strokeWidth }: DonutChartProps) => {
           return (
             <g key={segment.id}>
               <path d={pathData} fill="none" stroke={segment.color} strokeWidth={strokeWidth} />
-              {segment.percentage >= 5 && (
+              {segment.id !== -1 && segment.percentage >= 5 && (
                 <text
                   x={labelX}
                   y={labelY}


### PR DESCRIPTION
## 📄 Summary
<img width="905" alt="Screenshot 2023-08-03 at 5 47 50 PM" src="https://github.com/woowacourse-teams/2023-hang-log/assets/51967731/a77b79d2-35df-4e55-88f0-a30de3e1917b">


## 🙋🏻 More
close #305 
