### PR TITLE
ExpensePage DayLog ordinal 순서대로 정렬 

### DIFF
--- a/frontend/src/components/common/TripItemList/TripItemList.tsx
+++ b/frontend/src/components/common/TripItemList/TripItemList.tsx
@@ -1,10 +1,9 @@
+import { sortByOrdinal } from '@/utils/sort';
 import { PATH } from '@constants/path';
 import type { TripItemData } from '@type/tripItem';
 import { Button, Divider, Heading, Text } from 'hang-log-design-system';
 import { Fragment, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-import { sortByOrdinal } from '@utils/sortByStartDate';
 
 import { useDayLogOrderMutation } from '@hooks/api/useDayLogOrderMutation';
 import { useDragAndDrop } from '@hooks/common/useDragAndDrop';

--- a/frontend/src/components/expense/ExpenseDates/ExpenseDates.tsx
+++ b/frontend/src/components/expense/ExpenseDates/ExpenseDates.tsx
@@ -1,8 +1,8 @@
-import { sortByOrdinal } from '@/utils/sort';
 import { CURRENCY_ICON, DEFAULT_CURRENCY } from '@constants/trip';
 import { Flex, Heading, Tab, Tabs, Text, Theme, useSelect } from 'hang-log-design-system';
 
 import { formatDate, formatMonthDate, formatNumberToMoney } from '@utils/formatter';
+import { sortByOrdinal } from '@utils/sort';
 
 import { useExpense } from '@hooks/expense/useExpense';
 

--- a/frontend/src/components/expense/ExpenseDates/ExpenseDates.tsx
+++ b/frontend/src/components/expense/ExpenseDates/ExpenseDates.tsx
@@ -1,3 +1,4 @@
+import { sortByOrdinal } from '@/utils/sort';
 import { CURRENCY_ICON, DEFAULT_CURRENCY } from '@constants/trip';
 import { Flex, Heading, Tab, Tabs, Text, Theme, useSelect } from 'hang-log-design-system';
 
@@ -14,10 +15,12 @@ interface ExpenseDatesProps {
 
 const ExpenseDates = ({ tripId }: ExpenseDatesProps) => {
   const { expenseData, dates } = useExpense(tripId);
+  const sortedExpenseDayLog = expenseData.dayLogs.sort(sortByOrdinal);
+
   const { selected: selectedDayLogId, handleSelectClick: handleDayLogIdSelectClick } = useSelect(
-    expenseData.dayLogs[0].id
+    sortedExpenseDayLog[0].id
   );
-  const selectedDayLog = expenseData.dayLogs.find((log) => log.id === selectedDayLogId)!;
+  const selectedDayLog = sortedExpenseDayLog.find((log) => log.id === selectedDayLogId)!;
 
   return (
     <>

--- a/frontend/src/pages/TripsPage/TripsPage.tsx
+++ b/frontend/src/pages/TripsPage/TripsPage.tsx
@@ -1,9 +1,8 @@
+import { sortByStartDate } from '@/utils/sort';
 import { ORDER_BY_DATE, ORDER_BY_REGISTRATION } from '@constants/order';
 import { PATH } from '@constants/path';
 import { FloatingButton, useSelect } from 'hang-log-design-system';
 import { useNavigate } from 'react-router-dom';
-
-import { sortByStartDate } from '@utils/sortByStartDate';
 
 import { useTripsQuery } from '@hooks/api/useTripsQuery';
 

--- a/frontend/src/stories/trips/TripsItemList.stories.tsx
+++ b/frontend/src/stories/trips/TripsItemList.stories.tsx
@@ -1,7 +1,6 @@
+import { sortByStartDate } from '@/utils/sort';
 import { trips } from '@mocks/data/trips';
 import type { Meta, StoryObj } from '@storybook/react';
-
-import { sortByStartDate } from '@utils/sortByStartDate';
 
 import TripsItemList from '@components/trips/TripsItemList/TripsItemList';
 

--- a/frontend/src/types/expense.ts
+++ b/frontend/src/types/expense.ts
@@ -20,6 +20,14 @@ export interface ExpenseItemData {
   };
 }
 
+export interface ExpenseDayLogData {
+  id: number;
+  ordinal: number;
+  date: string;
+  totalAmount: number;
+  items: ExpenseItemData[];
+}
+
 export interface ExpenseData {
   id: number;
   title: string;
@@ -42,13 +50,7 @@ export interface ExpenseData {
       rate: number;
     }[];
   };
-  dayLogs: {
-    id: number;
-    ordinal: number;
-    date: string;
-    totalAmount: number;
-    items: ExpenseItemData[];
-  }[];
+  dayLogs: ExpenseDayLogData[];
 }
 
 export interface CategoryExpenseType {

--- a/frontend/src/utils/sort.ts
+++ b/frontend/src/utils/sort.ts
@@ -1,3 +1,4 @@
+import type { ExpenseDayLogData } from '@type/expense';
 import type { TripItemData } from '@type/tripItem';
 import type { TripsData } from '@type/trips';
 
@@ -8,6 +9,9 @@ export const sortByStartDate = (a: TripsData, b: TripsData) => {
   return dateA.getTime() - dateB.getTime();
 };
 
-export const sortByOrdinal = (a: TripItemData, b: TripItemData) => {
+export const sortByOrdinal = (
+  a: TripItemData | ExpenseDayLogData,
+  b: TripItemData | ExpenseDayLogData
+) => {
   return a.ordinal - b.ordinal;
 };


### PR DESCRIPTION
## 📄 Summary
expense daylog 데이터가 현재 안 정렬된 상태로 와서 정렬해야 한다.

\* 달리(@waterricecake)가 나중에 고쳐 준다고 함, 그런데 일단 임시방편으로 프론트 쪽에서 정렬

## 🙋🏻 More
close #311 
