### PR TITLE
info 로그 파일에 request 정보 추가  #333

### DIFF
--- a/backend/src/main/java/filter/RequestLoggingFilter.java
+++ b/backend/src/main/java/filter/RequestLoggingFilter.java
@@ -1,6 +1,7 @@
 package filter;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.AbstractRequestLoggingFilter;
 
@@ -8,12 +9,12 @@ import org.springframework.web.filter.AbstractRequestLoggingFilter;
 public class RequestLoggingFilter extends AbstractRequestLoggingFilter {
 
     @Override
-    protected void beforeRequest(final HttpServletRequest request, final String message) {
+    protected void beforeRequest(@NonNull final HttpServletRequest request, @NonNull final String message) {
         logger.info(message);
     }
 
     @Override
-    protected void afterRequest(final HttpServletRequest request, final String message) {
+    protected void afterRequest(@NonNull final HttpServletRequest request, @NonNull final String message) {
         logger.info(message);
     }
 }

--- a/backend/src/main/java/filter/RequestLoggingFilter.java
+++ b/backend/src/main/java/filter/RequestLoggingFilter.java
@@ -1,0 +1,19 @@
+package filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.AbstractRequestLoggingFilter;
+
+@Slf4j
+public class RequestLoggingFilter extends AbstractRequestLoggingFilter {
+
+    @Override
+    protected void beforeRequest(final HttpServletRequest request, final String message) {
+        logger.info(message);
+    }
+
+    @Override
+    protected void afterRequest(final HttpServletRequest request, final String message) {
+        logger.info(message);
+    }
+}

--- a/backend/src/main/java/hanglog/config/RequestLoggingConfig.java
+++ b/backend/src/main/java/hanglog/config/RequestLoggingConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RequestLoggingConfig {
 
-    public static int MAX_PAYLOAD_LENGTH = 1000;
+    private static final int MAX_PAYLOAD_LENGTH = 1000;
 
     @Bean
     public RequestLoggingFilter loggingFilter() {

--- a/backend/src/main/java/hanglog/config/RequestLoggingConfig.java
+++ b/backend/src/main/java/hanglog/config/RequestLoggingConfig.java
@@ -1,0 +1,22 @@
+package hanglog.config;
+
+import filter.RequestLoggingFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RequestLoggingConfig {
+
+    public static int MAX_PAYLOAD_LENGTH = 1000;
+
+    @Bean
+    public RequestLoggingFilter loggingFilter() {
+        RequestLoggingFilter filter = new RequestLoggingFilter();
+        filter.setIncludeClientInfo(false);
+        filter.setIncludeHeaders(false);
+        filter.setIncludePayload(true);
+        filter.setIncludeQueryString(true);
+        filter.setMaxPayloadLength(MAX_PAYLOAD_LENGTH);
+        return filter;
+    }
+}

--- a/backend/src/main/resources/info-appender.xml
+++ b/backend/src/main/resources/info-appender.xml
@@ -7,14 +7,10 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>
                 <pattern>
-                    {
                     "timestamp": "%date{yyyy-MM-dd HH:mm}",
-                    "message": "%message"
-                    }
+                    ${CONSOLE_LOG_PATTERN}\n
                 </pattern>
-            </pattern>
             <charset>utf8</charset>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">


### PR DESCRIPTION
## 📄 Summary
> #333 

요청한 시간과 해당 요청에 대한 정보를 기록하도록 변경했습니다.
현재 build.gradle에 p6psy 있어서 지저분한데 그거 없애고 로그 찍어보면 다음과 같이 나옴
<img width="934" alt="image" src="https://github.com/woowacourse-teams/2023-hang-log/assets/77482065/0ca3e6ed-647f-4db2-9c4c-da528546e9cd">


RequestLoggingConfig 클래스 보면 Payload와 QueryString만 찍히게 설정해 놨는데, 나중에 필요하면 다른 것도 true로 바꾸면 될듯

## 🙋🏻 More
> 벌써 이슈번호가 333이라니 레전드
맘에 안드는거 있으면 언제든지 말해주세요 
말만
