### PR TITLE
지도 확대 시 경로 이상하게 표시되는 문제 해결

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -10,4 +10,6 @@ export default defineConfig({
   env: {
     NODE_ENV: 'development',
   },
+  video: false,
+  screenshotOnRunFailure: false,
 });

--- a/frontend/src/components/common/TripMap/TripMap.tsx
+++ b/frontend/src/components/common/TripMap/TripMap.tsx
@@ -1,4 +1,4 @@
-import { MAP_INITIAL_ZOOM_SIZE, MAP_MAX_ZOOM_SIZE } from '@constants/map';
+import { MAP_INITIAL_ZOOM_SIZE, MAP_MAX_ZOOM_SIZE, MAP_MIN_ZOOM_SIZE } from '@constants/map';
 import type { TripPlaceType } from '@type/trip';
 import { useEffect, useRef, useState } from 'react';
 
@@ -25,6 +25,7 @@ const TripMap = ({ centerLat, centerLng, places }: TripMapProps) => {
       const initialMap = new google.maps.Map(wrapperRef.current, {
         center: { lat: centerLat, lng: centerLng },
         zoom: MAP_INITIAL_ZOOM_SIZE,
+        minZoom: MAP_MIN_ZOOM_SIZE,
         maxZoom: MAP_MAX_ZOOM_SIZE,
         disableDefaultUI: true,
         mapId: process.env.GOOGLE_MAP_ID,

--- a/frontend/src/constants/map.ts
+++ b/frontend/src/constants/map.ts
@@ -2,4 +2,6 @@ export const MAP_INITIAL_ZOOM_SIZE = 13;
 
 export const MAP_MAX_ZOOM_SIZE = 18;
 
+export const MAP_MIN_ZOOM_SIZE = 2;
+
 export const MAP_ZOOM_OUT_LABEL_LIMIT = 14;


### PR DESCRIPTION
## 📄 Summary
<img width="2035" alt="image" src="https://github.com/woowacourse-teams/2023-hang-log/assets/52229930/1b88af69-fe76-46e2-8be8-b81867a874e2">

이 문제가 생긴 이유가 지도를 많이 줌 아웃하면 좌표 위치가 여러 곳에서 보여서 구글 맵이 어디에 좌표를 찍어햐 하는지 제대로 인지를 못해서 생긴 문제입니다. 그래서 최대로 줌 아웃할 수 있는 minZoom 값을 추가했습니다. 

<img width="1728" alt="Screenshot 2023-08-08 at 1 32 32 PM" src="https://github.com/woowacourse-teams/2023-hang-log/assets/51967731/51dd8303-e86e-4a4b-aad9-d7311d75a10d">
최대로 여기까지 줌 아웃 가능

## 🙋🏻 More
close #351 
