### PR TITLE
feat: daylog 및 카테고리 반환 순서 보장

### DIFF
--- a/backend/src/main/java/hanglog/expense/service/ExpenseService.java
+++ b/backend/src/main/java/hanglog/expense/service/ExpenseService.java
@@ -19,7 +19,7 @@ import hanglog.trip.domain.Trip;
 import hanglog.trip.domain.TripCity;
 import hanglog.trip.domain.repository.TripCityRepository;
 import hanglog.trip.domain.repository.TripRepository;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -107,7 +107,7 @@ public class ExpenseService {
     }
 
     private Map<DayLog, Integer> getDayLogAmounts(final List<DayLog> dayLogs) {
-        final Map<DayLog, Integer> dayLogAmounts = new HashMap<>();
+        final Map<DayLog, Integer> dayLogAmounts = new LinkedHashMap<>();
         for (final DayLog dayLog : dayLogs) {
             dayLogAmounts.put(dayLog, 0);
         }
@@ -116,7 +116,7 @@ public class ExpenseService {
 
     private Map<Category, Integer> getCategoryAmounts() {
         final List<Category> categories = categoryRepository.findExpenseCategory();
-        final Map<Category, Integer> categoryAmounts = new HashMap<>();
+        final Map<Category, Integer> categoryAmounts = new LinkedHashMap<>();
         for (final Category category : categories) {
             categoryAmounts.put(category, 0);
         }


### PR DESCRIPTION
## 📄 Summary
>#357

`HashMap`이 순서가 보장되지 않아 `LinkedHashMap`으로 바꾸어 줬습니다.
테스트의 경우 Repo가 순서가 보장이 되어있다는 가정하에 진행되어야하는 테스트라 불가능하여 일단 @SpringBootTest로 진행하여 성공한 사진을 첨부합니다. 이 후 expense 통합테스트 케이스를 통해 구현해 두겠습니다.

- before(HashMap)
<img width="51" alt="스크린샷 2023-08-08 오후 7 23 29" src="https://github.com/woowacourse-teams/2023-hang-log/assets/91263263/b32d626e-650d-4e98-b8bb-e7cae27334fb">

- after(LinkedHashMap)
<img width="70" alt="스크린샷 2023-08-08 오후 7 24 11" src="https://github.com/woowacourse-teams/2023-hang-log/assets/91263263/7403d54e-c167-42af-8b96-1c6f7dbd53dd">

## 🙋🏻 More
>
