### PR TITLE
데이로그 테스트 추가

### DIFF
--- a/backend/src/test/java/hanglog/trip/fixture/IntegrationFixture.java
+++ b/backend/src/test/java/hanglog/trip/fixture/IntegrationFixture.java
@@ -1,0 +1,96 @@
+package hanglog.trip.fixture;
+
+import static hanglog.image.util.ImageUrlConverter.convertNameToUrl;
+
+import hanglog.category.dto.CategoryResponse;
+import hanglog.expense.dto.response.ItemExpenseResponse;
+import hanglog.trip.dto.response.DayLogGetResponse;
+import hanglog.trip.dto.response.ItemResponse;
+import hanglog.trip.dto.response.PlaceResponse;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public class IntegrationFixture {
+
+    private static final CategoryResponse CATEGORY_FOOD = new CategoryResponse(100L, "음식");
+    private static final CategoryResponse CATEGORY_CULTURE = new CategoryResponse(200L, "문화");
+    private static final CategoryResponse CATEGORY_UNIVERSITY = new CategoryResponse(264L, "대학교");
+    private static final CategoryResponse CATEGORY_SHOPPING = new CategoryResponse(300L, "쇼핑");
+    private static final CategoryResponse CATEGORY_ACCOMMODATION = new CategoryResponse(400L, "숙박");
+    private static final CategoryResponse CATEGORY_TRANSPORTATION = new CategoryResponse(500L, "교통");
+    private static final CategoryResponse CATEGORY_ETC = new CategoryResponse(600L, "기타");
+
+    private static final PlaceResponse ITEM_1_PLACE = new PlaceResponse(
+            1L,
+            "캘리포니아 대학교",
+            new BigDecimal("37.8701510000000"),
+            new BigDecimal("-122.2594606000000"),
+            CATEGORY_UNIVERSITY
+    );
+    private static final ItemExpenseResponse ITEM_1_EXPENSE = new ItemExpenseResponse(
+            1L,
+            "usd",
+            10.0,
+            CATEGORY_FOOD
+    );
+    public static final ItemResponse ITEM_1 = new ItemResponse(
+            1L,
+            true,
+            "캘리포니아 대학 제목",
+            1,
+            3.5,
+            "캘리포니아 학식 메모",
+            List.of(convertNameToUrl("test1.jpeg")),
+            ITEM_1_PLACE,
+            ITEM_1_EXPENSE
+    );
+    private static final PlaceResponse ITEM_2_PLACE = new PlaceResponse(
+            2L,
+            "캘리포니아, 어바인 대학",
+            new BigDecimal("33.6423814000000"),
+            new BigDecimal("-117.8416747000000"),
+            CATEGORY_UNIVERSITY
+    );
+    private static final ItemExpenseResponse ITEM_2_EXPENSE = new ItemExpenseResponse(
+            2L,
+            "usd",
+            5.0,
+            CATEGORY_CULTURE
+    );
+    public static final ItemResponse ITEM_2 = new ItemResponse(
+            2L,
+            true,
+            "캘리포니아 어바인 대학 제목",
+            2,
+            3.5,
+            "캘리포니아 어바인 메모",
+            List.of(convertNameToUrl("test2.jpeg")),
+            ITEM_2_PLACE,
+            ITEM_2_EXPENSE
+    );
+    private static final ItemExpenseResponse ITEM_3_EXPENSE = new ItemExpenseResponse(
+            3L,
+            "usd",
+            100.0,
+            CATEGORY_SHOPPING
+    );
+    public static final ItemResponse ITEM_3 = new ItemResponse(
+            3L,
+            false,
+            "캘리포니아 어바인 쇼핑 제목",
+            3,
+            4.5,
+            "캘리포니아 어바인 쇼핑 메모",
+            List.of(convertNameToUrl("test3.jpeg")),
+            null,
+            ITEM_3_EXPENSE
+    );
+    public static final DayLogGetResponse DAY_LOG_1 = new DayLogGetResponse(
+            1L,
+            "0801",
+            1,
+            LocalDate.of(2023, 8, 1),
+            List.of(ITEM_1, ITEM_2, ITEM_3)
+    );
+}

--- a/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
+++ b/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
@@ -1,0 +1,114 @@
+package hanglog.trip.integration;
+
+import static hanglog.trip.fixture.IntegrationFixture.DAY_LOG_1;
+import static hanglog.trip.fixture.IntegrationFixture.ITEM_1;
+import static hanglog.trip.fixture.IntegrationFixture.ITEM_2;
+import static hanglog.trip.fixture.IntegrationFixture.ITEM_3;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import hanglog.global.IntegrationTest;
+import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
+import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
+import hanglog.trip.dto.response.DayLogGetResponse;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class DayLogIntegrationTest extends IntegrationTest {
+
+    @DisplayName("데이로그를 조회한다.")
+    @Test
+    void getDayLog() {
+        // given
+        final DayLogGetResponse expected = new DayLogGetResponse(
+                DAY_LOG_1.getId(),
+                DAY_LOG_1.getTitle(),
+                DAY_LOG_1.getOrdinal(),
+                DAY_LOG_1.getDate(),
+                DAY_LOG_1.getItems()
+        );
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when().get("/trips/1/daylogs/1")
+                .then().log().all()
+                .extract();
+        final DayLogGetResponse result = response.as(DayLogGetResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(result).usingRecursiveComparison()
+                .ignoringExpectedNullFields()
+                .isEqualTo(expected);
+    }
+
+    @DisplayName("데이로그 제목을 업데이트한다")
+    @Test
+    void updateDayLogTitle() {
+        // given
+        final String updatedTitle = "바꾼 제목";
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest(updatedTitle);
+        final DayLogGetResponse expected = new DayLogGetResponse(
+                DAY_LOG_1.getId(),
+                updatedTitle,
+                DAY_LOG_1.getOrdinal(),
+                DAY_LOG_1.getDate(),
+                DAY_LOG_1.getItems()
+        );
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().patch("/trips/1/daylogs/1")
+                .then().log().all()
+                .extract();
+        final DayLogGetResponse result = RestAssured.given().log().all()
+                .when().get("/trips/1/daylogs/1")
+                .then().log().all()
+                .extract().as(DayLogGetResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(result).usingRecursiveComparison()
+                .ignoringExpectedNullFields()
+                .isEqualTo(expected);
+    }
+
+    @DisplayName("데이로그의_아이템_순서를_업데이트한다")
+    @Test
+    void updateOrdinalOfItems() {
+        // given
+        final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(List.of(2L, 3L, 1L));
+        final DayLogGetResponse expected = new DayLogGetResponse(
+                DAY_LOG_1.getId(),
+                DAY_LOG_1.getTitle(),
+                DAY_LOG_1.getOrdinal(),
+                DAY_LOG_1.getDate(),
+                List.of(ITEM_2, ITEM_3, ITEM_1)
+        );
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().patch("/trips/1/daylogs/1/order")
+                .then().log().all()
+                .extract();
+        final DayLogGetResponse result = RestAssured.given().log().all()
+                .when().get("/trips/1/daylogs/1")
+                .then().log().all()
+                .extract().as(DayLogGetResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(result).usingRecursiveComparison()
+                .ignoringFieldsMatchingRegexes(".*ordinal")
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
+++ b/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -125,6 +126,39 @@ class DayLogControllerTest extends RestDocsTest {
                 );
     }
 
+    @DisplayName("제목이 null일 경우 예외가 발생한다.")
+    @Test
+    void updateDayLogTitle_TitleNull() throws Exception {
+        // given
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest(null);
+
+        doNothing().when(dayLogService).updateTitle(anyLong(), any(DayLogUpdateTitleRequest.class));
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("제목을 입력해주세요."));
+    }
+
+    @DisplayName("제목이 50자를 초과할 경우 예외가 발생한다.")
+    @Test
+    void updateDayLogTitle_TitleSizeInvalid() throws Exception {
+        // given
+        final String invalidSizeTitle = "1" + "1234567890".repeat(5);
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest(invalidSizeTitle);
+
+        doNothing().when(dayLogService).updateTitle(anyLong(), any(DayLogUpdateTitleRequest.class));
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("날짜별 제목은 50자를 초과할 수 없습니다."));
+    }
+
     @DisplayName("데이로그의 아이템들 순서를 변경할 수 있다.")
     @Test
     void updateOrdinalOfItems() throws Exception {
@@ -154,5 +188,53 @@ class DayLogControllerTest extends RestDocsTest {
                                 )
                         )
                 );
+    }
+
+    @DisplayName("아이템에 null이 입력되면 예외가 발생한다.")
+    @Test
+    void updateOrdinalOfItems_ItemsNull() throws Exception {
+        //given
+        final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(null);
+
+        doNothing().when(dayLogService).updateOrdinalOfItems(any(), any());
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}/order", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("아이템 아이디들을 입력해주세요."));
+    }
+
+    @DisplayName("아이템에 빈 리스트가 입력되면 예외가 발생한다.")
+    @Test
+    void updateOrdinalOfItems_ItemsEmpty() throws Exception {
+        //given
+        final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(List.of());
+
+        doNothing().when(dayLogService).updateOrdinalOfItems(any(), any());
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}/order", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("아이템 아이디들을 입력해주세요."));
+    }
+
+    @DisplayName("중복된 아이템이 입력되면 예외가 발생한다.")
+    @Test
+    void updateOrdinalOfItems_ItemsNotUnique() throws Exception {
+        //given
+        final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(List.of(3L, 2L, 1L, 1L));
+
+        doNothing().when(dayLogService).updateOrdinalOfItems(any(), any());
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}/order", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("중복되지 않는 아이템 아이디들을 입력해주세요."));
     }
 }

--- a/backend/src/test/resources/data/integration-data.sql
+++ b/backend/src/test/resources/data/integration-data.sql
@@ -51,7 +51,7 @@ INSERT INTO expense(category_id, currency, amount, created_at, modified_at, stat
 VALUES (300, 'usd', 100, now(), now(), 'USABLE');
 INSERT INTO item(day_log_id, expense_id, place_id, title, item_type, memo, ordinal, rating, created_at, modified_at,
                  status)
-VALUES (1, 3, null, '캘리포니아 어바인 쇼핑 제목', 'SPOT', '캘리포니아 어바인 쇼핑 메모', 3, 4.5, now(), now(), 'USABLE');
+VALUES (1, 3, null, '캘리포니아 어바인 쇼핑 제목', 'NON_SPOT', '캘리포니아 어바인 쇼핑 메모', 3, 4.5, now(), now(), 'USABLE');
 INSERT INTO image(item_id, `name`, created_at, modified_at, status)
 VALUES (3, 'test3.jpeg', now(), now(), 'USABLE');
 


### PR DESCRIPTION
## 📄 Summary
-  #356 
-  데이로그 컨트롤러 통합 테스트 & 슬라이스 DTO 테스트 추가
-  테스트 데이터 중에 논스팟인데 스팟으로 적혀있는 아이템 있어서 수정했습니다.

## 🙋🏻 More
- 서비스-레포지토리 테스트까지 한번에 구현할까 하다가 일단 지금 구현한 방식이 맞는지 모르겠어서 검사받으려고 PR올림.  
 서비스-레포지토리 테스트는 내일 배포서버 설정 하고나서 구현할게요.
- 통합테스트 인수테스튼가 싶어서 한글로 작성했다가 다시 영어로 바꿨음. 뭐가 맞나요?
- Fixture 다른것도 다만들려다가 이것도 맞는지 모르겠어서 일단 제가 필요한것만 만들고 스탑했습니당. 피드백 부탁.
