### PR TITLE
데이로그 컨트롤러 통합 테스트, dto 테스트 구현

### DIFF
--- a/backend/src/main/java/hanglog/trip/domain/Item.java
+++ b/backend/src/main/java/hanglog/trip/domain/Item.java
@@ -179,6 +179,9 @@ public class Item extends BaseEntity {
     }
 
     private void validateExpenseRange(final Expense expense) {
+        if (expense == null) {
+            return;
+        }
         final Amount amount = expense.getAmount();
         if (amount.compareTo(MIN_AMOUNT_VALUE) < 0) {
             throw new InvalidDomainException(INVALID_EXPENSE_UNDER_MIN);

--- a/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
+++ b/backend/src/main/java/hanglog/trip/dto/request/ItemRequest.java
@@ -51,7 +51,8 @@ public class ItemRequest {
             final String memo,
             final Long dayLogId,
             final List<String> imageUrls,
-            final PlaceRequest place, final ExpenseRequest expense
+            final PlaceRequest place,
+            final ExpenseRequest expense
     ) {
         validateExistPlaceWhenSpot(itemType, place);
         validateNoExistPlaceWhenNonSpot(itemType, place);

--- a/backend/src/main/java/hanglog/trip/dto/response/DayLogResponse.java
+++ b/backend/src/main/java/hanglog/trip/dto/response/DayLogResponse.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class DayLogGetResponse {
+public class DayLogResponse {
 
     private final Long id;
     private final String title;
@@ -16,12 +16,12 @@ public class DayLogGetResponse {
     private final LocalDate date;
     private final List<ItemResponse> items;
 
-    public static DayLogGetResponse of(final DayLog dayLog) {
+    public static DayLogResponse of(final DayLog dayLog) {
         final List<ItemResponse> itemResponses = dayLog.getItems().stream()
                 .map(ItemResponse::of)
                 .toList();
 
-        return new DayLogGetResponse(
+        return new DayLogResponse(
                 dayLog.getId(),
                 dayLog.getTitle(),
                 dayLog.getOrdinal(),

--- a/backend/src/main/java/hanglog/trip/dto/response/TripDetailResponse.java
+++ b/backend/src/main/java/hanglog/trip/dto/response/TripDetailResponse.java
@@ -24,7 +24,7 @@ public class TripDetailResponse {
     private final List<DayLogResponse> dayLogs;
 
     public static TripDetailResponse of(final Trip trip, final List<City> cities) {
-        final List<DayLogResponse> dayLogRespons = trip.getDayLogs().stream()
+        final List<DayLogResponse> dayLogResponses = trip.getDayLogs().stream()
                 .map(DayLogResponse::of)
                 .toList();
 
@@ -40,7 +40,7 @@ public class TripDetailResponse {
                 trip.getEndDate(),
                 trip.getDescription(),
                 convertNameToUrl(trip.getImageName()),
-                dayLogRespons
+                dayLogResponses
         );
     }
 }

--- a/backend/src/main/java/hanglog/trip/dto/response/TripDetailResponse.java
+++ b/backend/src/main/java/hanglog/trip/dto/response/TripDetailResponse.java
@@ -21,11 +21,11 @@ public class TripDetailResponse {
     private final LocalDate endDate;
     private final String description;
     private final String imageUrl;
-    private final List<DayLogGetResponse> dayLogs;
+    private final List<DayLogResponse> dayLogs;
 
     public static TripDetailResponse of(final Trip trip, final List<City> cities) {
-        final List<DayLogGetResponse> dayLogGetResponses = trip.getDayLogs().stream()
-                .map(DayLogGetResponse::of)
+        final List<DayLogResponse> dayLogRespons = trip.getDayLogs().stream()
+                .map(DayLogResponse::of)
                 .toList();
 
         final List<CityWithPositionResponse> cityWithPositionResponses = cities.stream()
@@ -40,7 +40,7 @@ public class TripDetailResponse {
                 trip.getEndDate(),
                 trip.getDescription(),
                 convertNameToUrl(trip.getImageName()),
-                dayLogGetResponses
+                dayLogRespons
         );
     }
 }

--- a/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
+++ b/backend/src/main/java/hanglog/trip/presentation/DayLogController.java
@@ -3,7 +3,7 @@ package hanglog.trip.presentation;
 
 import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
-import hanglog.trip.dto.response.DayLogGetResponse;
+import hanglog.trip.dto.response.DayLogResponse;
 import hanglog.trip.service.DayLogService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,10 +23,10 @@ public class DayLogController {
     private final DayLogService dayLogService;
 
     @GetMapping
-    public ResponseEntity<DayLogGetResponse> getDayLog(
+    public ResponseEntity<DayLogResponse> getDayLog(
             @PathVariable final Long tripId,
             @PathVariable final Long dayLogId) {
-        final DayLogGetResponse response = dayLogService.getById(dayLogId);
+        final DayLogResponse response = dayLogService.getById(dayLogId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/hanglog/trip/service/DayLogService.java
+++ b/backend/src/main/java/hanglog/trip/service/DayLogService.java
@@ -14,7 +14,7 @@ import hanglog.trip.domain.repository.DayLogRepository;
 import hanglog.trip.domain.repository.ItemRepository;
 import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
-import hanglog.trip.dto.response.DayLogGetResponse;
+import hanglog.trip.dto.response.DayLogResponse;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,12 +32,12 @@ public class DayLogService {
     private final ItemRepository itemRepository;
 
     @Transactional(readOnly = true)
-    public DayLogGetResponse getById(final Long id) {
+    public DayLogResponse getById(final Long id) {
         final DayLog dayLog = dayLogRepository.findById(id)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_TRIP_ID));
         validateAlreadyDeleted(dayLog);
 
-        return DayLogGetResponse.of(dayLog);
+        return DayLogResponse.of(dayLog);
     }
 
     public void updateTitle(final Long id, final DayLogUpdateTitleRequest request) {

--- a/backend/src/test/java/hanglog/global/IntegrationFixture.java
+++ b/backend/src/test/java/hanglog/global/IntegrationFixture.java
@@ -1,0 +1,133 @@
+package hanglog.global;
+
+import static hanglog.trip.domain.type.ItemType.SPOT;
+
+import hanglog.category.domain.Category;
+import hanglog.expense.domain.Amount;
+import hanglog.expense.domain.Expense;
+import hanglog.image.domain.Image;
+import hanglog.trip.domain.City;
+import hanglog.trip.domain.DayLog;
+import hanglog.trip.domain.Item;
+import hanglog.trip.domain.Place;
+import hanglog.trip.domain.Trip;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public class IntegrationFixture {
+
+    /* Category */
+    public static final Category FOOD_CATEGORY = new Category(100L, "food", "음식");
+    public static final Category CULTURE_CATEGORY = new Category(200L, "culture", "문화");
+    public static final Category UNIVERSITY_CATEGORY = new Category(264L, "university", "대학교");
+    public static final Category SHOPPING_CATEGORY = new Category(300L, "shopping", "쇼핑");
+    public static final Category ACCOMMODATION_CATEGORY = new Category(400L, "accommodation", "숙박");
+    public static final Category TRANSPORTATION_CATEGORY = new Category(500L, "transportation", "교통");
+    public static final Category ETC_CATEGORY = new Category(600L, "etc", "기타");
+
+    /* City */
+    public static final City LONDON = new City(
+            1L,
+            "런던",
+            "영국",
+            new BigDecimal("51.5072178"),
+            new BigDecimal("-0.1275862")
+    );
+
+    public static final City EDINBURGH = new City(
+            2L,
+            "에든버러",
+            "영국",
+            new BigDecimal("55.953252"),
+            new BigDecimal("-3.188267")
+    );
+
+    public static final City PARIS = new City(
+            3L,
+            "파리",
+            "프랑스",
+            new BigDecimal("48.856614"),
+            new BigDecimal("2.3522219")
+    );
+    public static final City TOKYO = new City(
+            4L,
+            "일본",
+            "도쿄",
+            new BigDecimal("35.6761919"),
+            new BigDecimal("139.6503106")
+    );
+
+    /* Place */
+    private static final Place PICCADILLY_CIRCUS = new Place(
+            "피카딜리 서커스",
+            new BigDecimal("51.510173624674515"),
+            new BigDecimal("-0.1349577015912248"),
+            CULTURE_CATEGORY
+    );
+
+    private static final Place COVENT_GARDEN = new Place(
+            "코벤트 가든",
+            new BigDecimal("51.51218732746311"),
+            new BigDecimal("-0.12276122266403186"),
+            CULTURE_CATEGORY
+    );
+
+    private static final Place BRITISH_MUSEUM = new Place(
+            "영국 박물관",
+            new BigDecimal("51.519583537867035"),
+            new BigDecimal("-0.12698878659703797"),
+            CULTURE_CATEGORY
+    );
+
+    /* Trip */
+    public static final LocalDate START_DATE = LocalDate.of(2023, 8, 1);
+    public static final LocalDate END_DATE = LocalDate.of(2023, 8, 3);
+    public static final Trip LAHGON_TRIP = Trip.of("런던 여행", START_DATE, END_DATE);
+
+    /* DayLog */
+    private static final DayLog DAY_LOG_1 = new DayLog(
+            "런던 방문기",
+            1,
+            LAHGON_TRIP
+    );
+
+    /* Item */
+    private static final Image DEFAULT_IMAGE = new Image("default-image.png");
+
+    private static final Item PICCADILLY_CIRCUS_ITEM = new Item(
+            SPOT,
+            "피카딜리 서커스",
+            1,
+            4.0,
+            "북적북적한 피키달리 서커스",
+            PICCADILLY_CIRCUS,
+            DAY_LOG_1,
+            new Expense("gbp", new Amount(200.0), CULTURE_CATEGORY),
+            List.of(DEFAULT_IMAGE)
+    );
+
+    private static final Item COVENT_GARDEN_ITEM = new Item(
+            SPOT,
+            "코벤트 가든",
+            2,
+            4.5,
+            "이 세상에서 제일 맛있는 애프터눈 티랑 스콘",
+            COVENT_GARDEN,
+            DAY_LOG_1,
+            new Expense("gbp", new Amount(80.0), FOOD_CATEGORY),
+            List.of(DEFAULT_IMAGE)
+    );
+
+    private static final Item BRITISH_MUSEUM_ITEM = new Item(
+            SPOT,
+            "대영박물관",
+            3,
+            3.0,
+            "세계의 역사를 볼 수 있는 대영박물관",
+            BRITISH_MUSEUM,
+            DAY_LOG_1,
+            new Expense("gbp", new Amount(0.0), CULTURE_CATEGORY),
+            List.of(DEFAULT_IMAGE)
+    );
+}

--- a/backend/src/test/java/hanglog/global/IntegrationTest.java
+++ b/backend/src/test/java/hanglog/global/IntegrationTest.java
@@ -12,13 +12,17 @@ import org.springframework.test.context.jdbc.Sql;
         "classpath:data/truncate.sql",
         "classpath:data/currency.sql",
         "classpath:data/cities.sql",
-        "classpath:data/categories.sql",
-        "classpath:data/integration-data.sql"
+        "classpath:data/categories.sql"
 })
 public abstract class IntegrationTest {
 
     @LocalServerPort
     int port;
+
+    public static String parseUri(final String uri) {
+        final String[] parts = uri.split("/");
+        return parts[parts.length - 1];
+    }
 
     @BeforeEach
     void setPort() {

--- a/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
+++ b/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
@@ -1,0 +1,101 @@
+package hanglog.trip.integration;
+
+import static hanglog.global.IntegrationFixture.EDINBURGH;
+import static hanglog.global.IntegrationFixture.END_DATE;
+import static hanglog.global.IntegrationFixture.LONDON;
+import static hanglog.global.IntegrationFixture.START_DATE;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import hanglog.global.IntegrationTest;
+import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
+import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
+import hanglog.trip.dto.request.TripCreateRequest;
+import hanglog.trip.dto.response.DayLogResponse;
+import hanglog.trip.dto.response.TripDetailResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class DayLogIntegrationTest extends IntegrationTest {
+
+    private Long tripId;
+    private Long dayLogId;
+
+    @BeforeEach
+    void setUp() {
+        final TripCreateRequest tripCreateRequest = new TripCreateRequest(
+                START_DATE,
+                END_DATE,
+                Arrays.asList(LONDON.getId(), EDINBURGH.getId())
+        );
+
+        final ExtractableResponse<Response> tripCreateResponse = TripIntegrationTest.requestCreateTrip(
+                tripCreateRequest);
+        tripId = Long.parseLong(parseUri(tripCreateResponse.header("Location")));
+
+        final ExtractableResponse<Response> tripGetResponse = TripIntegrationTest.requestGetTrips(tripId);
+        final TripDetailResponse tripDetailResponse = tripGetResponse.as(TripDetailResponse.class);
+        dayLogId = tripDetailResponse.getDayLogs().get(0).getId();
+    }
+
+    @DisplayName("데이로그를 조회한다.")
+    @Test
+    void getDayLog() {
+        // given
+        final DayLogResponse expected = new DayLogResponse(
+                dayLogId,
+                "",
+                1,
+                START_DATE,
+                new ArrayList<>()
+        );
+
+        // when
+        final ExtractableResponse<Response> response = requestGetDayLog(tripId, dayLogId);
+        final DayLogResponse result = response.as(DayLogResponse.class);
+
+        // then
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                    softly.assertThat(result).usingRecursiveComparison()
+                            .isEqualTo(expected);
+                }
+        );
+    }
+
+    private ExtractableResponse<Response> requestGetDayLog(final Long tripId, final Long dayLogId) {
+        return RestAssured
+                .given().log().all()
+                .when().get("/trips/{tripId}/daylogs/{dayLogId}", tripId, dayLogId)
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> requestUpdateDayLogTitle(final DayLogUpdateTitleRequest request) {
+        return RestAssured
+                .given().log().all()
+                .contentType(JSON)
+                .body(request)
+                .when().patch("/trips/{tripId}/daylogs/{dayLogId}", tripId, dayLogId)
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> requestUpdateOrdinalOfItems(final ItemsOrdinalUpdateRequest request) {
+        return RestAssured
+                .given().log().all()
+                .contentType(JSON)
+                .body(request)
+                .when().patch("/trips/{tripId}/daylogs/{dayLogId}/order", tripId, dayLogId)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
+++ b/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
@@ -44,7 +44,7 @@ public class DayLogIntegrationTest extends IntegrationTest {
         );
         tripId = Long.parseLong(parseUri(tripCreateResponse.header("Location")));
 
-        final ExtractableResponse<Response> tripGetResponse = TripIntegrationTest.requestGetTrips(tripId);
+        final ExtractableResponse<Response> tripGetResponse = TripIntegrationTest.requestGetTrip(tripId);
         final TripDetailResponse tripDetailResponse = tripGetResponse.as(TripDetailResponse.class);
         dayLogId = tripDetailResponse.getDayLogs().get(0).getId();
     }

--- a/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
+++ b/backend/src/test/java/hanglog/trip/integration/DayLogIntegrationTest.java
@@ -71,6 +71,27 @@ public class DayLogIntegrationTest extends IntegrationTest {
         );
     }
 
+    @DisplayName("데이로그 제목을 업데이트한다")
+    @Test
+    void updateDayLogTitle() {
+        // given
+        final String updatedTitle = "수정된 제목";
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest(updatedTitle);
+
+        // when
+        final ExtractableResponse<Response> response = requestUpdateDayLogTitle(request);
+        final ExtractableResponse<Response> dayLogGetResponse = requestGetDayLog(tripId, dayLogId);
+        final DayLogResponse dayLogResponse = dayLogGetResponse.as(DayLogResponse.class);
+
+        // then
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+                    softly.assertThat(dayLogResponse.getTitle()).isEqualTo(updatedTitle);
+                }
+        );
+    }
+
     private ExtractableResponse<Response> requestGetDayLog(final Long tripId, final Long dayLogId) {
         return RestAssured
                 .given().log().all()

--- a/backend/src/test/java/hanglog/trip/integration/ItemIntegrationTest.java
+++ b/backend/src/test/java/hanglog/trip/integration/ItemIntegrationTest.java
@@ -1,0 +1,22 @@
+package hanglog.trip.integration;
+
+import static io.restassured.http.ContentType.JSON;
+
+import hanglog.global.IntegrationTest;
+import hanglog.trip.dto.request.ItemRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class ItemIntegrationTest extends IntegrationTest {
+
+    protected static ExtractableResponse<Response> requestCreateItem(final Long tripId, final ItemRequest itemRequest) {
+        return RestAssured
+                .given().log().all()
+                .contentType(JSON)
+                .body(itemRequest)
+                .when().post("/trips/{tripId}/items", tripId)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/hanglog/trip/integration/TripIntegrationTest.java
+++ b/backend/src/test/java/hanglog/trip/integration/TripIntegrationTest.java
@@ -31,7 +31,7 @@ public class TripIntegrationTest extends IntegrationTest {
                 .extract();
     }
 
-    protected static ExtractableResponse<Response> requestGetTrips(final Long tripId) {
+    protected static ExtractableResponse<Response> requestGetTrip(final Long tripId) {
         return RestAssured
                 .given().log().all()
                 .when().get("/trips/{tripId}", tripId)

--- a/backend/src/test/java/hanglog/trip/integration/TripIntegrationTest.java
+++ b/backend/src/test/java/hanglog/trip/integration/TripIntegrationTest.java
@@ -1,0 +1,41 @@
+package hanglog.trip.integration;
+
+import static hanglog.global.IntegrationFixture.EDINBURGH;
+import static hanglog.global.IntegrationFixture.END_DATE;
+import static hanglog.global.IntegrationFixture.LONDON;
+import static hanglog.global.IntegrationFixture.START_DATE;
+import static io.restassured.http.ContentType.JSON;
+
+import hanglog.global.IntegrationTest;
+import hanglog.trip.dto.request.TripCreateRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Arrays;
+
+public class TripIntegrationTest extends IntegrationTest {
+
+    final TripCreateRequest tripCreateRequest = new TripCreateRequest(
+            START_DATE,
+            END_DATE,
+            Arrays.asList(LONDON.getId(), EDINBURGH.getId())
+    );
+
+    protected static ExtractableResponse<Response> requestCreateTrip(final TripCreateRequest tripCreateRequest) {
+        return RestAssured
+                .given().log().all()
+                .contentType(JSON)
+                .body(tripCreateRequest)
+                .when().post("/trips")
+                .then().log().all()
+                .extract();
+    }
+
+    protected static ExtractableResponse<Response> requestGetTrips(final Long tripId) {
+        return RestAssured
+                .given().log().all()
+                .when().get("/trips/{tripId}", tripId)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
+++ b/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -125,6 +126,39 @@ class DayLogControllerTest extends RestDocsTest {
                 );
     }
 
+    @DisplayName("제목이 null일 경우 예외가 발생한다.")
+    @Test
+    void updateDayLogTitle_TitleNull() throws Exception {
+        // given
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest(null);
+
+        doNothing().when(dayLogService).updateTitle(anyLong(), any(DayLogUpdateTitleRequest.class));
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("제목을 입력해주세요."));
+    }
+
+    @DisplayName("제목이 50자를 초과할 경우 예외가 발생한다.")
+    @Test
+    void updateDayLogTitle_TitleSizeInvalid() throws Exception {
+        // given
+        final String invalidSizeTitle = "1" + "1234567890".repeat(5);
+        final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest(invalidSizeTitle);
+
+        doNothing().when(dayLogService).updateTitle(anyLong(), any(DayLogUpdateTitleRequest.class));
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("날짜별 제목은 50자를 초과할 수 없습니다."));
+    }
+
     @DisplayName("데이로그의 아이템들 순서를 변경할 수 있다.")
     @Test
     void updateOrdinalOfItems() throws Exception {
@@ -154,5 +188,53 @@ class DayLogControllerTest extends RestDocsTest {
                                 )
                         )
                 );
+    }
+
+    @DisplayName("아이템에 null이 입력되면 예외가 발생한다.")
+    @Test
+    void updateOrdinalOfItems_ItemsNull() throws Exception {
+        //given
+        final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(null);
+
+        doNothing().when(dayLogService).updateOrdinalOfItems(any(), any());
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}/order", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("아이템 아이디들을 입력해주세요."));
+    }
+
+    @DisplayName("아이템에 빈 리스트가 입력되면 예외가 발생한다.")
+    @Test
+    void updateOrdinalOfItems_ItemsEmpty() throws Exception {
+        //given
+        final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(List.of());
+
+        doNothing().when(dayLogService).updateOrdinalOfItems(any(), any());
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}/order", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("아이템 아이디들을 입력해주세요."));
+    }
+
+    @DisplayName("중복된 아이템이 입력되면 예외가 발생한다.")
+    @Test
+    void updateOrdinalOfItems_ItemsNotUnique() throws Exception {
+        //given
+        final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(List.of(3L, 2L, 1L, 1L));
+
+        doNothing().when(dayLogService).updateOrdinalOfItems(any(), any());
+
+        // when & then
+        mockMvc.perform(patch("/trips/{tripId}/daylogs/{dayLogId}/order", 1L, 1L)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("중복되지 않는 아이템 아이디들을 입력해주세요."));
     }
 }

--- a/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
+++ b/backend/src/test/java/hanglog/trip/presentation/DayLogControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
-import hanglog.trip.dto.response.DayLogGetResponse;
+import hanglog.trip.dto.response.DayLogResponse;
 import hanglog.trip.restdocs.RestDocsTest;
 import hanglog.trip.service.DayLogService;
 import java.time.LocalDate;
@@ -47,7 +47,7 @@ class DayLogControllerTest extends RestDocsTest {
     @Test
     void getDayLog() throws Exception {
         // given
-        final DayLogGetResponse response = new DayLogGetResponse(
+        final DayLogResponse response = new DayLogResponse(
                 1L,
                 "런던 여행 첫날",
                 1,

--- a/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
@@ -15,7 +15,7 @@ import hanglog.trip.domain.repository.DayLogRepository;
 import hanglog.trip.domain.repository.ItemRepository;
 import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
-import hanglog.trip.dto.response.DayLogGetResponse;
+import hanglog.trip.dto.response.DayLogResponse;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +42,7 @@ class DayLogServiceTest {
     @Test
     void getDayLogById() {
         // given
-        final DayLogGetResponse expected = new DayLogGetResponse(
+        final DayLogResponse expected = new DayLogResponse(
                 1L,
                 "런던 여행 1일차",
                 1,
@@ -53,7 +53,7 @@ class DayLogServiceTest {
                 .willReturn(Optional.of(LONDON_DAYLOG_1));
 
         // when
-        final DayLogGetResponse actual = dayLogService.getById(LONDON_DAYLOG_1.getId());
+        final DayLogResponse actual = dayLogService.getById(LONDON_DAYLOG_1.getId());
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);

--- a/backend/src/test/resources/data/integration-data.sql
+++ b/backend/src/test/resources/data/integration-data.sql
@@ -51,7 +51,7 @@ INSERT INTO expense(category_id, currency, amount, created_at, modified_at, stat
 VALUES (300, 'usd', 100, now(), now(), 'USABLE');
 INSERT INTO item(day_log_id, expense_id, place_id, title, item_type, memo, ordinal, rating, created_at, modified_at,
                  status)
-VALUES (1, 3, null, '캘리포니아 어바인 쇼핑 제목', 'SPOT', '캘리포니아 어바인 쇼핑 메모', 3, 4.5, now(), now(), 'USABLE');
+VALUES (1, 3, null, '캘리포니아 어바인 쇼핑 제목', 'NON_SPOT', '캘리포니아 어바인 쇼핑 메모', 3, 4.5, now(), now(), 'USABLE');
 INSERT INTO image(item_id, `name`, created_at, modified_at, status)
 VALUES (3, 'test3.jpeg', now(), now(), 'USABLE');
 


### PR DESCRIPTION
## 📄 Summary
 #356   
테스트 방식이 확정되고 새로 만든 테스트입니다.  
라온 pr에서 논의한대로 DayLogGetResponse -> DayLogResponse로 변경하여 FilesChanged는 많은데 실제로 변경한 파일은 많지 않으니 참고해주세요.

dto 테스트는 이전과 동일하고, 통합 테스트는 대부분 변경하였습니다.  
투표 결과에 따라 데이터 주입은 sql, fixture는 도메인, 메소드 명은 영어로 통일하였습니다.  


## 🙋🏻 More
아이템 순서 변경 테스트 구현으로 인해 아이템 생성 관련 메소드도 만들었습니다.
그러다가 Item expense가 null일 경우 오류생기는걸 발견해서 겸사겸사 버그픽스도 했습니다. 


이외에 테스트 짜다가 든 생각들 밑에 정리해 두었으니 참고 바랍니다. 
(혹시나 다른분들이랑 충돌날까봐 최대한 안바꿨는데 여러분거 짤때는 바꿔야할듯합니다?)

> PlaceRequest
> - 장소 카테고리 빈 배열로 올수도 있음 -> NotEmpty가 아니라 NotNull로 변경해야할듯.  

> IntegrationFixture
> - 장소 좌표가 소수점아래 13자리까지만 허용되기 때문에 좌표값 길이 줄여야함. 만약 더 긴 좌표가 들어올 수 있다고 생각한다면 제한을 늘려야 할듯?
> - 아이템 이미지 이름이 unique라서 (해싱할거기때문에 중복 막아놓음) default image 사용 불가. 각자 다른 이미지 이름 넣어줘야함.

