### PR TITLE
npm run build 시 오래 걸리는 문제 해결

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint": "eslint src",
-    "cypress": "cypress open"
+    "cypress": "cypress open",
+    "analyze": "webpack-bundle-analyzer ./dist/bundle-report.json --default-sizes gzip"
   },
   "keywords": [],
   "author": "",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -18,7 +18,13 @@ const plugins = [
   }),
   new webpack.HotModuleReplacementPlugin(),
   new Dotenv(),
-  new BundleAnalyzerPlugin(),
+  new BundleAnalyzerPlugin({
+    analyzerMode: 'static',
+    openAnalyzer: false,
+    generateStatsFile: true,
+    statsFilename: 'bundle-report.json',
+  }),
+
   new CompressionPlugin(),
 ];
 
@@ -97,6 +103,7 @@ module.exports = {
       '@utils': path.resolve(__dirname, './src/utils'),
     },
   },
+
   plugins,
 
   optimization: {


### PR DESCRIPTION
## 📄 Summary
webpack bundle analyzer 때문에 생기는 문제 같아요.........

## 🙋🏻 More
close #548 
