### PR TITLE
이미지 cache-control 메타데이터 값 변경

### DIFF
--- a/backend/src/main/java/hanglog/image/service/ImageService.java
+++ b/backend/src/main/java/hanglog/image/service/ImageService.java
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageService {
     private static final int MAX_IMAGE_LIST_SIZE = 5;
     private static final int EMPTY_LIST_SIZE = 0;
-    private static final String CACHE_CONTROL_VALUE = "max-age=31536000";
+    private static final String CACHE_CONTROL_VALUE = "max-age=3153600";
 
     private final AmazonS3 s3Client;
 


### PR DESCRIPTION
## 📄 Summary
#569

## 🙋🏻 More
> 알수없는 이유로 10배 값이 적용되어, 값을 변경해 주었습니다.
