### PR TITLE
refactor: 로그아웃 로직 변경

### DIFF
--- a/backend/src/main/java/hanglog/auth/domain/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/hanglog/auth/domain/repository/RefreshTokenRepository.java
@@ -4,10 +4,10 @@ import hanglog.auth.domain.RefreshToken;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
 
     Optional<RefreshToken> findByToken(final String token);
-    
+
     boolean existsByToken(final String token);
 
     void deleteByMemberId(final Long memberId);

--- a/backend/src/main/java/hanglog/auth/presentation/AuthController.java
+++ b/backend/src/main/java/hanglog/auth/presentation/AuthController.java
@@ -59,8 +59,10 @@ public class AuthController {
 
     @DeleteMapping("/logout")
     @MemberOnly
-    public ResponseEntity<Void> logout(@Auth final Accessor accessor) {
-        authService.removeMemberRefreshToken(accessor.getMemberId());
+    public ResponseEntity<Void> logout(
+            @Auth final Accessor accessor,
+            @CookieValue("refresh-token") final String refreshToken) {
+        authService.removeRefreshToken(refreshToken);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/hanglog/auth/service/AuthService.java
+++ b/backend/src/main/java/hanglog/auth/service/AuthService.java
@@ -1,5 +1,9 @@
 package hanglog.auth.service;
 
+import static hanglog.global.exception.ExceptionCode.FAIL_TO_GENERATE_RANDOM_NICKNAME;
+import static hanglog.global.exception.ExceptionCode.FAIL_TO_VALIDATE_TOKEN;
+import static hanglog.global.exception.ExceptionCode.INVALID_REFRESH_TOKEN;
+
 import hanglog.auth.domain.BearerAuthorizationExtractor;
 import hanglog.auth.domain.JwtProvider;
 import hanglog.auth.domain.MemberTokens;
@@ -15,8 +19,6 @@ import hanglog.trip.domain.repository.TripRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static hanglog.global.exception.ExceptionCode.*;
 
 @Service
 @Transactional
@@ -79,8 +81,8 @@ public class AuthService {
         throw new AuthException(FAIL_TO_VALIDATE_TOKEN);
     }
 
-    public void removeMemberRefreshToken(final Long memberId) {
-        refreshTokenRepository.deleteByMemberId(memberId);
+    public void removeRefreshToken(final String refreshToken) {
+        refreshTokenRepository.deleteById(refreshToken);
     }
 
     public void deleteAccount(final Long memberId) {

--- a/backend/src/test/java/hanglog/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/hanglog/auth/presentation/AuthControllerTest.java
@@ -161,7 +161,7 @@ class AuthControllerTest extends ControllerTest {
         given(refreshTokenRepository.existsByToken(any())).willReturn(true);
         doNothing().when(jwtProvider).validateTokens(any());
         given(jwtProvider.getSubject(any())).willReturn("1");
-        doNothing().when(authService).removeMemberRefreshToken(anyLong());
+        doNothing().when(authService).removeRefreshToken(anyString());
 
         final MemberTokens memberTokens = new MemberTokens(REFRESH_TOKEN, RENEW_ACCESS_TOKEN);
         final Cookie cookie = new Cookie("refresh-token", memberTokens.getRefreshToken());
@@ -186,7 +186,7 @@ class AuthControllerTest extends ControllerTest {
                 ));
 
         // then
-        verify(authService).removeMemberRefreshToken(anyLong());
+        verify(authService).removeRefreshToken(anyString());
     }
 
 


### PR DESCRIPTION
## 📄 Summary
> #669 

## 🙋🏻 More
> 기존의 memberId 기준으로 삭제하던 방식을 refreshToken을 기준으로 변경하였습니다.
