### PR TITLE
데이로그 아이템 사진 별개로 한개 추가시, 그 사진만 등록되는 버그수정

### DIFF
--- a/frontend/src/components/trip/TripInfoEditModal/ImageInput/ImageInput.tsx
+++ b/frontend/src/components/trip/TripInfoEditModal/ImageInput/ImageInput.tsx
@@ -25,6 +25,7 @@ const ImageInput = ({ initialImage, updateCoverImage }: ImageInputProps) => {
     initialImageUrls: initialImage === null ? [] : [initialImage],
     onSuccess: handleImageUrlsChange,
   });
+
   return (
     <ImageUploadInput
       id="cover-image-upload"

--- a/frontend/src/hooks/common/useMultipleImageUpload.ts
+++ b/frontend/src/hooks/common/useMultipleImageUpload.ts
@@ -77,7 +77,7 @@ export const useMultipleImageUpload = ({
         { images: imageUploadFormData },
         {
           onSuccess: ({ imageUrls }) => {
-            if (imageUrls.length === 1) {
+            if (maxUploadCount === 1) {
               onSuccess?.([...imageUrls]);
               createToast('이미지 업로드에 성공했습니다', 'success');
 


### PR DESCRIPTION
## 📄 Summary
>데이로그 아이템 사진 별개로 한개 추가시, 그 사진만 등록되는 버그수정

사진 최대 갯수로, 커버인지 아이템인지 판별하는 로직으로 변경 

## 🙋🏻 More
>
