### PR TITLE
아이템 생성&수정, DayLog수정&ordinal 수정 쿼리 개선

### DIFF
--- a/backend/src/main/java/hanglog/expense/domain/Expense.java
+++ b/backend/src/main/java/hanglog/expense/domain/Expense.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -58,5 +59,13 @@ public class Expense extends BaseEntity {
             final Category category
     ) {
         this(null, currency, amount, category);
+    }
+
+    public boolean isDifferent(final Expense expense) {
+        if (expense == null) {
+            return true;
+        }
+        return !(Objects.equals(currency, expense.currency) && Objects.equals(amount, expense.amount)
+                && Objects.equals(category, expense.category));
     }
 }

--- a/backend/src/main/java/hanglog/global/detector/ConnectionProxyHandler.java
+++ b/backend/src/main/java/hanglog/global/detector/ConnectionProxyHandler.java
@@ -1,0 +1,45 @@
+package hanglog.global.detector;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.framework.ProxyFactory;
+
+@RequiredArgsConstructor
+public class ConnectionProxyHandler implements MethodInterceptor {
+
+    private static final String JDBC_PREPARE_STATEMENT_METHOD_NAME = "prepareStatement";
+
+    private final Object connection;
+    private final LoggingForm loggingForm;
+
+    @Nullable
+    @Override
+    public Object invoke(@Nonnull final MethodInvocation invocation) throws Throwable {
+        final Object result = invocation.proceed();
+
+        if (hasConnection(result) && hasPreparedStatementInvoked(invocation)) {
+            final ProxyFactory proxyFactory = new ProxyFactory(result);
+            proxyFactory.addAdvice(new PreparedStatementProxyHandler(loggingForm));
+            return proxyFactory.getProxy();
+        }
+
+        return result;
+    }
+
+    private boolean hasPreparedStatementInvoked(final MethodInvocation invocation) {
+        return invocation.getMethod().getName().equals(JDBC_PREPARE_STATEMENT_METHOD_NAME);
+    }
+
+    private boolean hasConnection(final Object result) {
+        return result != null;
+    }
+
+    public Object getProxy() {
+        final ProxyFactory proxyFactory = new ProxyFactory(connection);
+        proxyFactory.addAdvice(this);
+        return proxyFactory.getProxy();
+    }
+}

--- a/backend/src/main/java/hanglog/global/detector/LoggingForm.java
+++ b/backend/src/main/java/hanglog/global/detector/LoggingForm.java
@@ -1,0 +1,30 @@
+package hanglog.global.detector;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class LoggingForm {
+
+    private String apiUrl;
+    private String apiMethod;
+    private Long queryCounts = 0L;
+    private Long queryTime = 0L;
+
+    public void queryCountUp() {
+        queryCounts++;
+    }
+
+    public void addQueryTime(final Long queryTime) {
+        this.queryTime += queryTime;
+    }
+
+    public void setApiUrl(final String apiUrl) {
+        this.apiUrl = apiUrl;
+    }
+
+    public void setApiMethod(final String apiMethod) {
+        this.apiMethod = apiMethod;
+    }
+}

--- a/backend/src/main/java/hanglog/global/detector/PreparedStatementProxyHandler.java
+++ b/backend/src/main/java/hanglog/global/detector/PreparedStatementProxyHandler.java
@@ -1,0 +1,37 @@
+package hanglog.global.detector;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+@RequiredArgsConstructor
+public class PreparedStatementProxyHandler implements MethodInterceptor {
+
+    private static final List<String> JDBC_QUERY_METHOD = List.of("executeQuery", "execute", "executeUpdate");
+
+    private final LoggingForm loggingForm;
+
+    @Nullable
+    @Override
+    public Object invoke(@Nonnull final MethodInvocation invocation) throws Throwable {
+
+        final Method method = invocation.getMethod();
+
+        if (JDBC_QUERY_METHOD.contains(method.getName())) {
+            final long startTime = System.currentTimeMillis();
+            final Object result = invocation.proceed();
+            final long endTime = System.currentTimeMillis();
+
+            loggingForm.addQueryTime(endTime - startTime);
+            loggingForm.queryCountUp();
+
+            return result;
+        }
+
+        return invocation.proceed();
+    }
+}

--- a/backend/src/main/java/hanglog/global/detector/QueryCounterAop.java
+++ b/backend/src/main/java/hanglog/global/detector/QueryCounterAop.java
@@ -1,0 +1,60 @@
+package hanglog.global.detector;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Slf4j
+@Component
+public class QueryCounterAop {
+
+    private final ThreadLocal<LoggingForm> currentLoggingForm;
+
+    public QueryCounterAop() {
+        this.currentLoggingForm = new ThreadLocal<>();
+    }
+
+    @Around("execution( * javax.sql.DataSource.getConnection())")
+    public Object captureConnection(final ProceedingJoinPoint joinPoint) throws Throwable {
+        final Object connection = joinPoint.proceed();
+
+        return new ConnectionProxyHandler(connection, getCurrentLoggingForm()).getProxy();
+    }
+
+    private LoggingForm getCurrentLoggingForm() {
+        if (currentLoggingForm.get() == null) {
+            currentLoggingForm.set(new LoggingForm());
+        }
+
+        return currentLoggingForm.get();
+    }
+
+    @After("within(@org.springframework.web.bind.annotation.RestController *)")
+    public void loggingAfterApiFinish() {
+        final LoggingForm loggingForm = getCurrentLoggingForm();
+
+        final ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        if (isInRequestScope(attributes)) {
+            final HttpServletRequest request = attributes.getRequest();
+
+            loggingForm.setApiMethod(request.getMethod());
+            loggingForm.setApiUrl(request.getRequestURI());
+        }
+
+        log.info("{}", getCurrentLoggingForm());
+        currentLoggingForm.remove();
+    }
+
+    private boolean isInRequestScope(final ServletRequestAttributes attributes) {
+        return attributes != null;
+    }
+}

--- a/backend/src/main/java/hanglog/image/domain/Image.java
+++ b/backend/src/main/java/hanglog/image/domain/Image.java
@@ -1,6 +1,5 @@
 package hanglog.image.domain;
 
-import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -32,7 +31,7 @@ public class Image extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
-    @ManyToOne(fetch = LAZY, cascade = {PERSIST})
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
 

--- a/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepository.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepository.java
@@ -1,0 +1,9 @@
+package hanglog.image.domain.repository;
+
+import hanglog.image.domain.Image;
+import java.util.List;
+
+public interface CustomImageRepository {
+
+    void saveAll(final List<Image> images);
+}

--- a/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepository.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface CustomImageRepository {
 
     void saveAll(final List<Image> images);
+
+    void deleteAll(final List<Image> images);
 }

--- a/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepositoryImpl.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepositoryImpl.java
@@ -1,0 +1,41 @@
+package hanglog.image.domain.repository;
+
+import hanglog.image.domain.Image;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CustomImageRepositoryImpl implements CustomImageRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public void saveAll(final List<Image> images) {
+        final String sql = """
+                    INSERT INTO image (created_at, modified_at, item_id, name, status) 
+                    VALUES (:createdAt, :modifiedAt, :itemId, :name, :status)
+                """;
+        namedParameterJdbcTemplate.batchUpdate(sql, getImageToSqlParameterSources(images));
+    }
+
+    private MapSqlParameterSource[] getImageToSqlParameterSources(final List<Image> images) {
+        return images.stream()
+                .map(this::getImageToSqlParameterSource)
+                .toArray(MapSqlParameterSource[]::new);
+    }
+
+    private MapSqlParameterSource getImageToSqlParameterSource(final Image image) {
+        final LocalDateTime now = LocalDateTime.now();
+        return new MapSqlParameterSource()
+                .addValue("createdAt", now)
+                .addValue("modifiedAt", now)
+                .addValue("itemId", image.getItem().getId())
+                .addValue("name", image.getName())
+                .addValue("status", image.getStatus().name());
+    }
+}

--- a/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepositoryImpl.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -21,6 +22,21 @@ public class CustomImageRepositoryImpl implements CustomImageRepository {
                     VALUES (:createdAt, :modifiedAt, :itemId, :name, :status)
                 """;
         namedParameterJdbcTemplate.batchUpdate(sql, getImageToSqlParameterSources(images));
+    }
+
+    @Override
+    public void deleteAll(final List<Image> images) {
+        final String sql = """
+                    DELETE FROM image WHERE id IN (:imageIds)
+                """;
+        namedParameterJdbcTemplate.update(sql, getDeletedImageIdsSqlParameterSources(images));
+    }
+
+    private SqlParameterSource getDeletedImageIdsSqlParameterSources(final List<Image> images) {
+        final List<Long> imageIds = images.stream()
+                .map(Image::getId)
+                .toList();
+        return new MapSqlParameterSource("imageIds", imageIds);
     }
 
     private MapSqlParameterSource[] getImageToSqlParameterSources(final List<Image> images) {

--- a/backend/src/main/java/hanglog/image/domain/repository/ImageRepository.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/ImageRepository.java
@@ -1,7 +1,15 @@
 package hanglog.image.domain.repository;
 
 import hanglog.image.domain.Image;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    @Modifying
+    @Query("DELETE FROM Image image WHERE image IN :images")
+    void deleteAll(@Param("images") final List<Image> images);
 }

--- a/backend/src/main/java/hanglog/image/domain/repository/ImageRepository.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/ImageRepository.java
@@ -1,15 +1,7 @@
 package hanglog.image.domain.repository;
 
 import hanglog.image.domain.Image;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
-
-    @Modifying
-    @Query("DELETE FROM Image image WHERE image IN :images")
-    void deleteAll(@Param("images") final List<Image> images);
 }

--- a/backend/src/main/java/hanglog/trip/domain/Item.java
+++ b/backend/src/main/java/hanglog/trip/domain/Item.java
@@ -4,7 +4,6 @@ import static hanglog.global.exception.ExceptionCode.INVALID_EXPENSE_OVER_MAX;
 import static hanglog.global.exception.ExceptionCode.INVALID_EXPENSE_UNDER_MIN;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 import static hanglog.global.type.StatusType.USABLE;
-import static jakarta.persistence.CascadeType.MERGE;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.EnumType.STRING;
@@ -68,15 +67,15 @@ public class Item extends BaseEntity {
 
     private String memo;
 
-    @OneToOne(fetch = LAZY, cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
+    @OneToOne(fetch = LAZY, cascade = REMOVE)
     @JoinColumn(name = "place_id")
     private Place place;
 
-    @ManyToOne(fetch = LAZY, cascade = {PERSIST})
+    @ManyToOne(fetch = LAZY, cascade = PERSIST)
     @JoinColumn(name = "day_log_id", nullable = false)
     private DayLog dayLog;
 
-    @OneToOne(fetch = LAZY, cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
+    @OneToOne(fetch = LAZY, cascade = REMOVE)
     @JoinColumn(name = "expense_id")
     private Expense expense;
 

--- a/backend/src/main/java/hanglog/trip/domain/Item.java
+++ b/backend/src/main/java/hanglog/trip/domain/Item.java
@@ -80,7 +80,7 @@ public class Item extends BaseEntity {
     @JoinColumn(name = "expense_id")
     private Expense expense;
 
-    @OneToMany(mappedBy = "item", fetch = LAZY, cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
+    @OneToMany(mappedBy = "item", fetch = LAZY, cascade = REMOVE)
     private List<Image> images = new ArrayList<>();
 
     public Item(

--- a/backend/src/main/java/hanglog/trip/domain/repository/CustomItemRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/CustomItemRepository.java
@@ -1,0 +1,8 @@
+package hanglog.trip.domain.repository;
+
+import java.util.List;
+
+public interface CustomItemRepository {
+
+    void updateOrdinals(final List<Long> orderedItemIds);
+}

--- a/backend/src/main/java/hanglog/trip/domain/repository/CustomItemRepositoryImpl.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/CustomItemRepositoryImpl.java
@@ -1,0 +1,37 @@
+package hanglog.trip.domain.repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CustomItemRepositoryImpl implements CustomItemRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public void updateOrdinals(final List<Long> orderedItemIds) {
+        final String sql = "UPDATE item SET ordinal = :newOrdinal WHERE id = :itemId";
+        final SqlParameterSource[] sqlParameterSources = getUpdateOrdinalsSqlParameterSources(orderedItemIds);
+        namedParameterJdbcTemplate.batchUpdate(sql, sqlParameterSources);
+    }
+
+    private SqlParameterSource[] getUpdateOrdinalsSqlParameterSources(final List<Long> orderedItemIds) {
+        final SqlParameterSource[] sqlParameterSources = new MapSqlParameterSource[orderedItemIds.size()];
+        for (int i = 0; i < orderedItemIds.size(); i++) {
+            final Long itemId = orderedItemIds.get(i);
+            final int newOrdinal = i + 1;
+            final Map<String, Object> sqlParameterSource = new HashMap<>();
+            sqlParameterSource.put("newOrdinal", newOrdinal);
+            sqlParameterSource.put("itemId", itemId);
+            sqlParameterSources[i] = new MapSqlParameterSource(sqlParameterSource);
+        }
+        return sqlParameterSources;
+    }
+}

--- a/backend/src/main/java/hanglog/trip/domain/repository/DayLogRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/DayLogRepository.java
@@ -1,7 +1,18 @@
 package hanglog.trip.domain.repository;
 
 import hanglog.trip.domain.DayLog;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DayLogRepository extends JpaRepository<DayLog, Long> {
+
+    @Query("""
+            SELECT dayLog
+            FROM DayLog dayLog
+            LEFT JOIN FETCH dayLog.items items
+            WHERE dayLog.id = :dayLogId
+            """)
+    Optional<DayLog> findWithItemById(@Param("dayLogId") final Long dayLogId);
 }

--- a/backend/src/main/java/hanglog/trip/domain/repository/DayLogRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/DayLogRepository.java
@@ -14,5 +14,18 @@ public interface DayLogRepository extends JpaRepository<DayLog, Long> {
             LEFT JOIN FETCH dayLog.items items
             WHERE dayLog.id = :dayLogId
             """)
-    Optional<DayLog> findWithItemById(@Param("dayLogId") final Long dayLogId);
+    Optional<DayLog> findWithItemsById(@Param("dayLogId") final Long dayLogId);
+
+    @Query("""
+            SELECT dayLog
+            FROM DayLog dayLog
+            LEFT JOIN FETCH dayLog.items items
+            LEFT JOIN FETCH items.images images
+            LEFT JOIN FETCH items.expense expense
+            LEFT JOIN FETCH items.place place
+            LEFT JOIN FETCH expense.category expense_category
+            LEFT JOIN FETCH place.category place_category
+            WHERE dayLog.id = :dayLogId
+            """)
+    Optional<DayLog> findWithItemDetailsById(@Param("dayLogId") final Long dayLogId);
 }

--- a/backend/src/main/java/hanglog/trip/service/ItemService.java
+++ b/backend/src/main/java/hanglog/trip/service/ItemService.java
@@ -15,7 +15,6 @@ import hanglog.expense.domain.repository.ExpenseRepository;
 import hanglog.global.exception.BadRequestException;
 import hanglog.image.domain.Image;
 import hanglog.image.domain.repository.CustomImageRepository;
-import hanglog.image.domain.repository.ImageRepository;
 import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.Item;
 import hanglog.trip.domain.Place;
@@ -41,7 +40,6 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final CategoryRepository categoryRepository;
     private final DayLogRepository dayLogRepository;
-    private final ImageRepository imageRepository;
     private final CustomImageRepository customImageRepository;
     private final PlaceRepository placeRepository;
     private final ExpenseRepository expenseRepository;
@@ -175,7 +173,7 @@ public class ItemService {
         if (deletedImages.isEmpty()) {
             return;
         }
-        imageRepository.deleteAll(deletedImages);
+        customImageRepository.deleteAll(deletedImages);
     }
 
     private Image makeUpdatedImage(final String imageUrl, final List<Image> originalImages, final Item item) {

--- a/backend/src/main/java/hanglog/trip/service/ItemService.java
+++ b/backend/src/main/java/hanglog/trip/service/ItemService.java
@@ -156,17 +156,26 @@ public class ItemService {
                 .map(imageUrl -> makeUpdatedImage(imageUrl, originalImages, item))
                 .toList();
 
-        final List<Image> deletedImages = originalImages.stream()
-                .filter(image -> !updatedImages.contains(image))
-                .toList();
-        imageRepository.deleteAll(deletedImages);
+        deleteNotUsedImages(originalImages, updatedImages);
+        saveNewImages(originalImages, updatedImages);
+        return updatedImages;
+    }
 
+    private void saveNewImages(final List<Image> originalImages, final List<Image> updatedImages) {
         final List<Image> newImages = updatedImages.stream()
                 .filter(image -> !originalImages.contains(image))
                 .toList();
         customImageRepository.saveAll(newImages);
+    }
 
-        return updatedImages;
+    private void deleteNotUsedImages(final List<Image> originalImages, final List<Image> updatedImages) {
+        final List<Image> deletedImages = originalImages.stream()
+                .filter(image -> !updatedImages.contains(image))
+                .toList();
+        if (deletedImages.isEmpty()) {
+            return;
+        }
+        imageRepository.deleteAll(deletedImages);
     }
 
     private Image makeUpdatedImage(final String imageUrl, final List<Image> originalImages, final Item item) {

--- a/backend/src/main/java/hanglog/trip/service/ItemService.java
+++ b/backend/src/main/java/hanglog/trip/service/ItemService.java
@@ -159,7 +159,7 @@ public class ItemService {
         final List<Image> deletedImages = originalImages.stream()
                 .filter(image -> !updatedImages.contains(image))
                 .toList();
-        imageRepository.deleteAllInBatch(deletedImages);
+        imageRepository.deleteAll(deletedImages);
 
         final List<Image> newImages = updatedImages.stream()
                 .filter(image -> !originalImages.contains(image))

--- a/backend/src/main/resources/info-appender.xml
+++ b/backend/src/main/resources/info-appender.xml
@@ -8,8 +8,7 @@
         </filter>
         <encoder>
                 <pattern>
-                    "timestamp": "%date{yyyy-MM-dd HH:mm}",
-                    ${CONSOLE_LOG_PATTERN}\n
+                    [%d{yyyy-MM-dd HH:mm:ss.SSS}] %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n%n
                 </pattern>
             <charset>utf8</charset>
         </encoder>

--- a/backend/src/test/java/hanglog/integration/controller/ItemIntegrationTest.java
+++ b/backend/src/test/java/hanglog/integration/controller/ItemIntegrationTest.java
@@ -156,9 +156,9 @@ public class ItemIntegrationTest extends IntegrationTest {
         );
     }
 
-    @DisplayName("NonSpot인 아이템을 Spot으로 수정한다.")
+    @DisplayName("Spot인 아이템을 NonSpot으로 수정한다.")
     @Test
-    void updateItem_NonSpotToSpot() {
+    void updateItem_SpotToNonSpot() {
         // when
         final ItemRequest itemRequest = getSpotItemRequest();
         final ExtractableResponse<Response> createResponse = requestCreateItem(memberTokens, tripId, itemRequest);
@@ -239,9 +239,9 @@ public class ItemIntegrationTest extends IntegrationTest {
         );
     }
 
-    @DisplayName("Spot에서 NonSpot으로 수정한다.")
+    @DisplayName("NonSpot에서 Spot으로 수정한다.")
     @Test
-    void updateItem_SpotToNonSpot() {
+    void updateItem_NonSpotToSpot() {
         // when
         final ItemRequest itemRequest = getNonSpotItemRequest();
         final ExtractableResponse<Response> createResponse = requestCreateItem(memberTokens, tripId, itemRequest);

--- a/backend/src/test/java/hanglog/integration/controller/ItemIntegrationTest.java
+++ b/backend/src/test/java/hanglog/integration/controller/ItemIntegrationTest.java
@@ -254,7 +254,7 @@ public class ItemIntegrationTest extends IntegrationTest {
                 "updated memo",
                 dayLogId,
                 List.of("https://hanglog.com/img/test1.png", "https://hanglog.com/img/test2.png"),
-                false,
+                true,
                 getPlaceRequest(),
                 getExpenseRequest()
         );

--- a/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
@@ -4,15 +4,13 @@ import static hanglog.trip.fixture.DayLogFixture.LONDON_DAYLOG_1;
 import static hanglog.trip.fixture.DayLogFixture.UPDATED_LONDON_DAYLOG;
 import static hanglog.trip.fixture.ItemFixture.DAYLOG_FOR_ITEM_FIXTURE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import hanglog.trip.domain.DayLog;
-import hanglog.trip.domain.Item;
+import hanglog.trip.domain.repository.CustomItemRepository;
 import hanglog.trip.domain.repository.DayLogRepository;
-import hanglog.trip.domain.repository.ItemRepository;
 import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
 import hanglog.trip.dto.response.DayLogResponse;
@@ -36,7 +34,7 @@ class DayLogServiceTest {
     private DayLogRepository dayLogRepository;
 
     @Mock
-    private ItemRepository itemRepository;
+    private CustomItemRepository customItemRepository;
 
     @DisplayName("날짜별 여행을 조회할 수 있다.")
     @Test
@@ -65,7 +63,7 @@ class DayLogServiceTest {
         // given
         final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest("updated");
 
-        given(dayLogRepository.findById(1L))
+        given(dayLogRepository.findWithItemsById(1L))
                 .willReturn(Optional.of(LONDON_DAYLOG_1));
         given(dayLogRepository.save(any(DayLog.class)))
                 .willReturn(UPDATED_LONDON_DAYLOG);
@@ -74,7 +72,7 @@ class DayLogServiceTest {
         dayLogService.updateTitle(LONDON_DAYLOG_1.getId(), request);
 
         // then
-        verify(dayLogRepository).findById(UPDATED_LONDON_DAYLOG.getId());
+        verify(dayLogRepository).findWithItemsById(UPDATED_LONDON_DAYLOG.getId());
         verify(dayLogRepository).save(any(DayLog.class));
     }
 
@@ -83,27 +81,13 @@ class DayLogServiceTest {
     void updateItemOrdinals() {
         // given
         final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(List.of(4L, 3L, 2L, 1L));
-        given(dayLogRepository.findById(1L))
+        given(dayLogRepository.findWithItemsById(1L))
                 .willReturn(Optional.of(DAYLOG_FOR_ITEM_FIXTURE));
-        given(itemRepository.findById(1L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(0)));
-        given(itemRepository.findById(2L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(1)));
-        given(itemRepository.findById(3L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(2)));
-        given(itemRepository.findById(4L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(3)));
 
         // when
         dayLogService.updateOrdinalOfItems(1L, request);
 
         // then
-        final List<Item> items = DAYLOG_FOR_ITEM_FIXTURE.getItems();
-        assertSoftly(softly -> {
-            softly.assertThat(items.get(0).getOrdinal()).isEqualTo(4);
-            softly.assertThat(items.get(1).getOrdinal()).isEqualTo(3);
-            softly.assertThat(items.get(2).getOrdinal()).isEqualTo(2);
-            softly.assertThat(items.get(3).getOrdinal()).isEqualTo(1);
-        });
+        verify(customItemRepository).updateOrdinals(any());
     }
 }

--- a/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import hanglog.category.domain.Category;
 import hanglog.category.domain.repository.CategoryRepository;
 import hanglog.category.fixture.CategoryFixture;
+import hanglog.expense.domain.repository.ExpenseRepository;
 import hanglog.global.exception.BadRequestException;
 import hanglog.image.domain.repository.CustomImageRepository;
 import hanglog.image.domain.repository.ImageRepository;
@@ -18,6 +19,7 @@ import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.Item;
 import hanglog.trip.domain.repository.DayLogRepository;
 import hanglog.trip.domain.repository.ItemRepository;
+import hanglog.trip.domain.repository.PlaceRepository;
 import hanglog.trip.domain.type.ItemType;
 import hanglog.trip.dto.request.ExpenseRequest;
 import hanglog.trip.dto.request.ItemRequest;
@@ -58,6 +60,12 @@ class ItemServiceTest {
     @Mock
     private CustomImageRepository customImageRepository;
 
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private ExpenseRepository expenseRepository;
+
     @DisplayName("새롭게 생성한 여행 아이템의 id를 반환한다.")
     @Test
     void save() {
@@ -82,7 +90,7 @@ class ItemServiceTest {
 
         given(itemRepository.save(any()))
                 .willReturn(ItemFixture.LONDON_EYE_ITEM);
-        given(dayLogRepository.findWithItemById(any()))
+        given(dayLogRepository.findWithItemsById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
         given(categoryRepository.findById(any()))
                 .willReturn(Optional.of(new Category(1L, "문화", "culture")));
@@ -118,7 +126,7 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(dayLogRepository.findWithItemById(any()))
+        given(dayLogRepository.findWithItemsById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
 
         // when & then
@@ -147,7 +155,7 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(dayLogRepository.findWithItemById(any()))
+        given(dayLogRepository.findWithItemsById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
 
         // when & then
@@ -170,15 +178,12 @@ class ItemServiceTest {
                 null,
                 expenseRequest
         );
-
-        given(itemRepository.save(any()))
-                .willReturn(ItemFixture.LONDON_EYE_ITEM);
-        given(itemRepository.findById(any()))
-                .willReturn(Optional.of(ItemFixture.LONDON_EYE_ITEM));
+        final DayLog dayLog = new DayLog("첫날", 1, TripFixture.LONDON_TRIP);
+        dayLog.addItem(ItemFixture.LONDON_EYE_ITEM);
         given(categoryRepository.findById(any()))
                 .willReturn(Optional.of(CategoryFixture.EXPENSE_CATEGORIES.get(1)));
-        given(dayLogRepository.findById(any()))
-                .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
+        given(dayLogRepository.findWithItemDetailsById(any()))
+                .willReturn(Optional.of(dayLog));
 
         // when
         itemService.update(1L, 1L, itemUpdateRequest);
@@ -210,14 +215,12 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(itemRepository.save(any()))
-                .willReturn(ItemFixture.LONDON_EYE_ITEM);
-        given(itemRepository.findById(any()))
-                .willReturn(Optional.of(ItemFixture.LONDON_EYE_ITEM));
+        final DayLog dayLog = new DayLog("첫날", 1, TripFixture.LONDON_TRIP);
+        dayLog.addItem(ItemFixture.LONDON_EYE_ITEM);
         given(categoryRepository.findById(any()))
                 .willReturn(Optional.of(CategoryFixture.EXPENSE_CATEGORIES.get(1)));
-        given(dayLogRepository.findById(any()))
-                .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
+        given(dayLogRepository.findWithItemDetailsById(any()))
+                .willReturn(Optional.of(dayLog));
 
         // when
         itemService.update(1L, 1L, itemUpdateRequest);

--- a/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
@@ -5,12 +5,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
 import hanglog.category.domain.Category;
 import hanglog.category.domain.repository.CategoryRepository;
 import hanglog.category.fixture.CategoryFixture;
 import hanglog.global.exception.BadRequestException;
+import hanglog.image.domain.repository.CustomImageRepository;
 import hanglog.image.domain.repository.ImageRepository;
 import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.Item;
@@ -53,6 +55,9 @@ class ItemServiceTest {
     @Mock
     private ImageRepository imageRepository;
 
+    @Mock
+    private CustomImageRepository customImageRepository;
+
     @DisplayName("새롭게 생성한 여행 아이템의 id를 반환한다.")
     @Test
     void save() {
@@ -77,10 +82,11 @@ class ItemServiceTest {
 
         given(itemRepository.save(any()))
                 .willReturn(ItemFixture.LONDON_EYE_ITEM);
-        given(dayLogRepository.findById(any()))
+        given(dayLogRepository.findWithItemById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
         given(categoryRepository.findById(any()))
                 .willReturn(Optional.of(new Category(1L, "문화", "culture")));
+        doNothing().when(customImageRepository).saveAll(any());
 
         // when
         final Long actualId = itemService.save(1L, itemRequest);
@@ -112,7 +118,7 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(dayLogRepository.findById(any()))
+        given(dayLogRepository.findWithItemById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
 
         // when & then
@@ -141,7 +147,7 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(dayLogRepository.findById(any()))
+        given(dayLogRepository.findWithItemById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
 
         // when & then

--- a/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
@@ -14,7 +14,6 @@ import hanglog.category.fixture.CategoryFixture;
 import hanglog.expense.domain.repository.ExpenseRepository;
 import hanglog.global.exception.BadRequestException;
 import hanglog.image.domain.repository.CustomImageRepository;
-import hanglog.image.domain.repository.ImageRepository;
 import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.Item;
 import hanglog.trip.domain.repository.DayLogRepository;
@@ -53,9 +52,6 @@ class ItemServiceTest {
 
     @Mock
     private DayLogRepository dayLogRepository;
-
-    @Mock
-    private ImageRepository imageRepository;
 
     @Mock
     private CustomImageRepository customImageRepository;


### PR DESCRIPTION
## 📄 Summary
크흠흠... `DayLog수정&ordinal 수정 쿼리 개선 코드가 별로 안나옴 + 둘이 겹치는 코드 존재`라는 이유로 같은 PR로 요청드리옵니다...^^ 양해부탁드립니다...^^

* 전반적으로 `Image`, `Place`, `Expense`의 CASCADE 옵션(Deleted만 남겨둠), orphanRemoval 삭제
   * CASCADE 옵션 사용시 쿼리가 하나씩 나가기 때문에 전부 지우고 batch update를 하게 변경함
   * CASCADE 옵션을 지움으로 인해, `placeRepository.save(place)`와 같이 Repository에서 직접 `Image`, `Place`, `Expense`를 저장하는 로직 추가됨

### 아이템 생성
> 쿼리 최대12개 -> 최대8개
* `DayLogRepository`에서 `findWithItemById` 메서드 구현 - 아이템 생성시 ordinal을 알아오기 위해 `DayLog`의 아이템 리스트 사이즈가 필요함. `DayLog`와 `Item`테이블에 각각 쿼리가 날아가는 것을 막기 위해 `Item`과 fetch join을 해서 가져오는 메서드 생성
* `CustomImageRepositoryImpl`의 saveAll메서드로 batch insert


### 아이템 수정
> 쿼리 최대 17개 -> 최대 10개
* `DayLogRepository`에서 `findWithItemDetailsById` 메서드 구현 - DayLog를 조회해올때 Item, Place, Expense, Category, Image 전부 fetch join해서 함께 조회
* `ImageRepository`에서 `deleteAll` 메서드로 이미지 리스트를 한 번에 삭제

### DayLog 수정
> 쿼리 4개 -> 3개
* `DayLog`와 `Item`을 각각 불러오던 것을 `DayLogRepository`의 `findWithItemById`로 한 번에 조회하게 변경

### DayLog의 아이템 ordinal 변경
> 쿼리 최대 23개 -> 3개
* `DayLog`와 `Item`을 각각 불러오던 것을 `DayLogRepository`의 `findWithItemById`로 한 번에 조회하게 변경 (3 -> 2)
* `CustomItemRepository`에서 아이템 ordinal batch update하게 변경 (20 -> 1)

## 🙋🏻 More
### 개선 쿼리 상세 내용
### 아이템 생성 최대 쿼리
* `tripService.validateTripByMember`로 인한 trip 조회 한 번
* dayLog 조회
* PlaceRequest의 apiCategory 조회
* ExpenseRequest의 category 조회
* insert place
* insert expense
* insert item
* batch insert image
```
select t1_0.id from trip t1_0 where (t1_0.status = 'USABLE') and t1_0.member_id=1 and t1_0.id=3 limit 1;

select d1_0.id,d1_0.created_at,i1_0.day_log_id,i1_0.id,i1_0.created_at,i1_0.expense_id,i1_0.item_type,i1_0.memo,i1_0.modified_at,i1_0.ordinal,i1_0.place_id,i1_0.rating,i1_0.status,i1_0.title,d1_0.modified_at,d1_0.ordinal,d1_0.status,d1_0.title,d1_0.trip_id from day_log d1_0 left join item i1_0 on d1_0.id=i1_0.day_log_id and (i1_0.status = 'USABLE')  where (d1_0.status = 'USABLE') and d1_0.id=1 order by i1_0.ordinal;

select c1_0.id,c1_0.created_at,c1_0.eng_name,c1_0.kor_name,c1_0.modified_at,c1_0.status from category c1_0 where (c1_0.status = 'USABLE') and c1_0.eng_name in ('food','cafe');

select c1_0.id,c1_0.created_at,c1_0.eng_name,c1_0.kor_name,c1_0.modified_at,c1_0.status from category c1_0 where c1_0.id=200 and (c1_0.status = 'USABLE');

insert into expense (amount,category_id,created_at,currency,modified_at,status) values (10000.0,200,'2023-10-10T17:20:29.768+0900','krw','2023-10-10T17:20:29.768+0900','USABLE');

insert into place (category_id,created_at,latitude,longitude,modified_at,name,status) values (100,'2023-10-10T17:20:29.870+0900',38.1111111111111,38.1111111111111,'2023-10-10T17:20:29.870+0900','힐튼 호텔','USABLE');

insert into item (created_at,day_log_id,expense_id,item_type,memo,modified_at,ordinal,place_id,rating,status,title) values ('2023-10-10T17:20:29.749+0900',1,33,'SPOT','힐튼 호텔에서 숙박을 했습니다.','2023-10-10T17:20:29.749+0900',12,31,3.5,'USABLE','힐튼 호텔');

h.global.detector.QueryCounterAop        : LoggingForm(apiUrl=/trips/3/items, apiMethod=POST, queryCounts=7, queryTime=49)

```

### 아이템 수정 최대 쿼리
* `tripService.validateTripByMember`로 인한 trip 조회 한 번
* dayLog 조회
* PlaceRequest의 apiCategory조회
* insert place
* insert expense
* 더 이상 사용하지 않는 이미지가 존재하면 delete where in
* 새로운 이미지가 존재하면 batch insert
* 아이템 update
* 사용하지 않는 Place가 존재하면 delete
* 사용하지 않는 Expense가 존재하면 delete
```
select t1_0.id from trip t1_0 where (t1_0.status = 'USABLE') and t1_0.member_id=1 and t1_0.id=3 limit 1;

select d1_0.id,d1_0.created_at,i1_0.day_log_id,i1_0.id,i1_0.created_at,e1_0.id,e1_0.amount,e1_0.category_id,c1_0.id,c1_0.created_at,c1_0.eng_name,c1_0.kor_name,c1_0.modified_at,c1_0.status,e1_0.created_at,e1_0.currency,e1_0.modified_at,e1_0.status,i2_0.item_id,i2_0.id,i2_0.created_at,i2_0.modified_at,i2_0.name,i2_0.status,i1_0.item_type,i1_0.memo,i1_0.modified_at,i1_0.ordinal,p1_0.id,p1_0.category_id,c2_0.id,c2_0.created_at,c2_0.eng_name,c2_0.kor_name,c2_0.modified_at,c2_0.status,p1_0.created_at,p1_0.latitude,p1_0.longitude,p1_0.modified_at,p1_0.name,p1_0.status,i1_0.rating,i1_0.status,i1_0.title,d1_0.modified_at,d1_0.ordinal,d1_0.status,d1_0.title,d1_0.trip_id from day_log d1_0 left join item i1_0 on d1_0.id=i1_0.day_log_id and (i1_0.status = 'USABLE')  left join image i2_0 on i1_0.id=i2_0.item_id and (i2_0.status = 'USABLE')  left join expense e1_0 on e1_0.id=i1_0.expense_id and (e1_0.status = 'USABLE') left join category c1_0 on c1_0.id=e1_0.category_id and (c1_0.status = 'USABLE') left join place p1_0 on p1_0.id=i1_0.place_id and (p1_0.status = 'USABLE') left join category c2_0 on c2_0.id=p1_0.category_id and (c2_0.status = 'USABLE') where (d1_0.status = 'USABLE') and d1_0.id=1 order by i1_0.ordinal;

select c1_0.id,c1_0.created_at,c1_0.eng_name,c1_0.kor_name,c1_0.modified_at,c1_0.status from category c1_0 where (c1_0.status = 'USABLE') and c1_0.eng_name in ('cafe','none');

insert into place (category_id,created_at,latitude,longitude,modified_at,name,status) values (122,'2023-10-11T03:48:07.294+0900',36.1111111111111,37.1111111111111,'2023-10-11T03:48:07.294+0900','변경dddd찐진찐마지막ㅇㅇㅇ이ㅡ아아악ㅇ!!!','USABLE');

insert into expense (amount,category_id,created_at,currency,modified_at,status) values (120.0,200,'2023-10-11T03:48:07.433+0900','krw','2023-10-11T03:48:07.433+0900','USABLE');

delete from image where id in (95,96);

update item set day_log_id=1,expense_id=54,item_type='SPOT',memo='맛있다!',modified_at='2023-10-11T03:48:07.572+0900',ordinal=13,place_id=49,rating=4.5,status='USABLE',title='이야아아dd아아아' where id=24;

UPDATE place SET status = 'DELETED' WHERE id = 48;

UPDATE expense SET status = 'DELETED' WHERE id = 50;

2023-10-11T03:48:07.668+09:00  INFO 4648 --- [nio-8080-exec-1] h.global.detector.QueryCounterAop        : LoggingForm(apiUrl=/trips/3/items/24, apiMethod=PUT, queryCounts=9, queryTime=28)
```
---
### DayLog 수정
* `tripService.validateTripByMember`로 인한 trip 조회 한 번
* `DayLog` 조회
* `DayLog` 제목 update
```
select t1_0.id from trip t1_0 where (t1_0.status = 'USABLE') and t1_0.member_id=1 and t1_0.id=3 limit 1;

select d1_0.id,d1_0.created_at,i1_0.day_log_id,i1_0.id,i1_0.created_at,i1_0.expense_id,i1_0.item_type,i1_0.memo,i1_0.modified_at,i1_0.ordinal,i1_0.place_id,i1_0.rating,i1_0.status,i1_0.title,d1_0.modified_at,d1_0.ordinal,d1_0.status,d1_0.title,d1_0.trip_id from day_log d1_0 left join item i1_0 on d1_0.id=i1_0.day_log_id and (i1_0.status = 'USABLE')  where (d1_0.status = 'USABLE') and d1_0.id=1 order by i1_0.ordinal;

update day_log set modified_at='2023-10-11T16:36:49.899+0900',ordinal=1,status='USABLE',title='내가진짜데이로그다!!!',trip_id=3 where id=1;

LoggingForm(apiUrl=/trips/3/daylogs/1, apiMethod=PATCH, queryCounts=3, queryTime=24)
```

### DayLog의 아이템 ordinal 변경
* `tripService.validateTripByMember`로 인한 trip 조회 한 번
* `DayLog` 조회
* 아이템 ordinal batch update
```
select t1_0.id from trip t1_0 where (t1_0.status = 'USABLE') and t1_0.member_id=1 and t1_0.id=3 limit 1;

select d1_0.id,d1_0.created_at,i1_0.day_log_id,i1_0.id,i1_0.created_at,i1_0.expense_id,i1_0.item_type,i1_0.memo,i1_0.modified_at,i1_0.ordinal,i1_0.place_id,i1_0.rating,i1_0.status,i1_0.title,d1_0.modified_at,d1_0.ordinal,d1_0.status,d1_0.title,d1_0.trip_id from day_log d1_0 left join item i1_0 on d1_0.id=i1_0.day_log_id and (i1_0.status = 'USABLE')  where (d1_0.status = 'USABLE') and d1_0.id=2 order by i1_0.ordinal;

LoggingForm(apiUrl=/trips/3/daylogs/2/order, apiMethod=PATCH, queryCounts=2, queryTime=3)
```
더 개선할 부분 보이시면 코멘트plz
close #690
close #695