### PR TITLE
단일 여행, 아이템 삭제 쿼리 개선

### DIFF
--- a/backend/src/main/java/hanglog/expense/domain/repository/ExpenseRepository.java
+++ b/backend/src/main/java/hanglog/expense/domain/repository/ExpenseRepository.java
@@ -11,9 +11,17 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     @Modifying
     @Query("""
-                UPDATE Expense expense
-                SET expense.status = 'DELETED'
-                WHERE expense.id IN :expenseIds
+            UPDATE Expense expense
+            SET expense.status = 'DELETED'
+            WHERE expense.id = :id
+            """)
+    void deleteById(@Param("id") final Long id);
+
+    @Modifying
+    @Query("""
+            UPDATE Expense expense
+            SET expense.status = 'DELETED'
+            WHERE expense.id IN :expenseIds
             """)
     void deleteByIds(@Param("expenseIds") final List<Long> expenseIds);
 }

--- a/backend/src/main/java/hanglog/image/domain/repository/ImageRepository.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/ImageRepository.java
@@ -11,9 +11,17 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     @Modifying
     @Query("""
-                UPDATE Image image
-                SET image.status = 'DELETED'
-                WHERE image.item.id IN :itemIds
+            UPDATE Image image
+            SET image.status = 'DELETED'
+            WHERE image.item.id = :itemId
+            """)
+    void deleteByItemId(@Param("itemId") final Long itemId);
+
+    @Modifying
+    @Query("""
+            UPDATE Image image
+            SET image.status = 'DELETED'
+            WHERE image.item.id IN :itemIds
             """)
     void deleteByItemIds(@Param("itemIds") final List<Long> itemIds);
 }

--- a/backend/src/main/java/hanglog/listener/DeleteEventListener.java
+++ b/backend/src/main/java/hanglog/listener/DeleteEventListener.java
@@ -4,11 +4,13 @@ import hanglog.auth.domain.repository.RefreshTokenRepository;
 import hanglog.expense.domain.repository.ExpenseRepository;
 import hanglog.image.domain.repository.ImageRepository;
 import hanglog.member.domain.MemberDeleteEvent;
+import hanglog.trip.domain.TripDeleteEvent;
 import hanglog.trip.domain.repository.CustomDayLogRepository;
 import hanglog.trip.domain.repository.CustomItemRepository;
 import hanglog.trip.domain.repository.DayLogRepository;
 import hanglog.trip.domain.repository.ItemRepository;
 import hanglog.trip.domain.repository.PlaceRepository;
+import hanglog.trip.domain.repository.TripCityRepository;
 import hanglog.trip.domain.repository.TripRepository;
 import hanglog.trip.dto.ItemElement;
 import java.util.List;
@@ -21,7 +23,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class MemberDeleteEventListener {
+public class DeleteEventListener {
 
     private final CustomDayLogRepository customDayLogRepository;
     private final CustomItemRepository customItemRepository;
@@ -30,13 +32,14 @@ public class MemberDeleteEventListener {
     private final ImageRepository imageRepository;
     private final ItemRepository itemRepository;
     private final DayLogRepository dayLogRepository;
+    private final TripCityRepository tripCityRepository;
     private final TripRepository tripRepository;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(fallbackExecution = true)
-    public void delete(final MemberDeleteEvent event) {
+    public void deleteMember(final MemberDeleteEvent event) {
         final List<Long> dayLogIds = customDayLogRepository.findDayLogIdsByTripIds(event.getTripIds());
         final List<ItemElement> itemElements = customItemRepository.findItemIdsByDayLogIds(dayLogIds);
 
@@ -47,6 +50,21 @@ public class MemberDeleteEventListener {
         dayLogRepository.deleteByIds(dayLogIds);
         tripRepository.deleteByMemberId(event.getMemberId());
         refreshTokenRepository.deleteByMemberId(event.getMemberId());
+    }
+    
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(fallbackExecution = true)
+    public void deleteTrip(final TripDeleteEvent event) {
+        final List<Long> dayLogIds = customDayLogRepository.findDayLogIdsByTripId(event.getTripId());
+        final List<ItemElement> itemElements = customItemRepository.findItemIdsByDayLogIds(dayLogIds);
+
+        deletePlaces(itemElements);
+        deleteExpenses(itemElements);
+        deleteImageAndItems(itemElements);
+
+        dayLogRepository.deleteByIds(dayLogIds);
+        tripCityRepository.deleteAllByTripId(event.getTripId());
     }
 
     private void deletePlaces(final List<ItemElement> itemElements) {

--- a/backend/src/main/java/hanglog/share/domain/repository/SharedTripRepository.java
+++ b/backend/src/main/java/hanglog/share/domain/repository/SharedTripRepository.java
@@ -16,6 +16,14 @@ public interface SharedTripRepository extends JpaRepository<SharedTrip, Long> {
     @Query("""
             UPDATE SharedTrip sharedTrip
             SET sharedTrip.status = 'DELETED'
+            WHERE sharedTrip.trip.id = :tripId
+            """)
+    void deleteByTripId(@Param("tripId") final Long tripId);
+
+    @Modifying
+    @Query("""
+            UPDATE SharedTrip sharedTrip
+            SET sharedTrip.status = 'DELETED'
             WHERE sharedTrip.trip.id IN :tripIds
             """)
     void deleteByTripIds(@Param("tripIds") final List<Long> tripIds);

--- a/backend/src/main/java/hanglog/trip/domain/TripDeleteEvent.java
+++ b/backend/src/main/java/hanglog/trip/domain/TripDeleteEvent.java
@@ -1,0 +1,11 @@
+package hanglog.trip.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TripDeleteEvent {
+
+    private final Long tripId;
+}

--- a/backend/src/main/java/hanglog/trip/domain/repository/CustomDayLogRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/CustomDayLogRepository.java
@@ -7,5 +7,7 @@ public interface CustomDayLogRepository {
 
     void saveAll(final List<DayLog> dayLogs);
 
+    List<Long> findDayLogIdsByTripId(final Long tripId);
+
     List<Long> findDayLogIdsByTripIds(final List<Long> tripIds);
 }

--- a/backend/src/main/java/hanglog/trip/domain/repository/ItemRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/ItemRepository.java
@@ -2,12 +2,33 @@ package hanglog.trip.domain.repository;
 
 import hanglog.trip.domain.Item;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    @Query("""
+            SELECT item
+            FROM Item item
+            LEFT JOIN FETCH item.images images
+            LEFT JOIN FETCH item.expense expense
+            LEFT JOIN FETCH item.place place
+            LEFT JOIN FETCH expense.category expense_category
+            LEFT JOIN FETCH place.category place_category
+            WHERE item.id = :itemId
+            """)
+    Optional<Item> findById(@Param("itemId") final Long itemId);
+
+    @Modifying
+    @Query("""
+            UPDATE Item item
+            SET item.status = 'DELETED'
+            WHERE item.id = :itemId
+            """)
+    void deleteById(@Param("itemId") final Long itemId);
 
     @Modifying
     @Query("""

--- a/backend/src/main/java/hanglog/trip/domain/repository/PlaceRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/PlaceRepository.java
@@ -11,9 +11,17 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     @Modifying
     @Query("""
-                UPDATE Place place
-                SET place.status = 'DELETED'
-                WHERE place.id IN :placeIds
+            UPDATE Place place
+            SET place.status = 'DELETED'
+            WHERE place.id = :id
+            """)
+    void deleteById(@Param("id") final Long id);
+
+    @Modifying
+    @Query("""
+            UPDATE Place place
+            SET place.status = 'DELETED'
+            WHERE place.id IN :placeIds
             """)
     void deleteByIds(@Param("placeIds") final List<Long> placeIds);
 }

--- a/backend/src/main/java/hanglog/trip/domain/repository/PublishedTripRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/PublishedTripRepository.java
@@ -10,11 +10,17 @@ import org.springframework.data.repository.query.Param;
 
 public interface PublishedTripRepository extends JpaRepository<PublishedTrip, Long> {
 
-    void deleteByTripId(final Long tripId);
-
     boolean existsByTripId(final Long tripId);
 
     Optional<PublishedTrip> findByTripId(final Long tripId);
+
+    @Modifying
+    @Query("""
+            UPDATE PublishedTrip publishedTrip
+            SET publishedTrip.status = 'DELETED'
+            WHERE publishedTrip.trip.id = :tripId
+            """)
+    void deleteByTripId(@Param("tripId") final Long tripId);
 
     @Modifying
     @Query("""

--- a/backend/src/main/java/hanglog/trip/domain/repository/TripCityRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/TripCityRepository.java
@@ -3,10 +3,19 @@ package hanglog.trip.domain.repository;
 import hanglog.trip.domain.TripCity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TripCityRepository extends JpaRepository<TripCity, Long> {
 
     List<TripCity> findByTripId(Long tripId);
 
-    void deleteAllByTripId(Long tripId);
+    @Modifying
+    @Query("""
+            UPDATE TripCity tripCity
+            SET tripCity.status = 'DELETED'
+            WHERE tripCity.trip.id = :tripId
+            """)
+    void deleteAllByTripId(@Param("tripId") final Long tripId);
 }

--- a/backend/src/main/java/hanglog/trip/domain/repository/TripRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/TripRepository.java
@@ -53,6 +53,14 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     @Query("""
             UPDATE  Trip trip
             SET trip.status = 'DELETED'
+            WHERE trip.id = :tripId
+            """)
+    void deleteById(@Param("tripId") final Long tripId);
+
+    @Modifying
+    @Query("""
+            UPDATE  Trip trip
+            SET trip.status = 'DELETED'
             WHERE trip.member.id = :memberId
             """)
     void deleteByMemberId(@Param("memberId") final Long memberId);

--- a/backend/src/main/java/hanglog/trip/infrastructure/CustomDayLogRepositoryImpl.java
+++ b/backend/src/main/java/hanglog/trip/infrastructure/CustomDayLogRepositoryImpl.java
@@ -25,6 +25,18 @@ public class CustomDayLogRepositoryImpl implements CustomDayLogRepository {
     }
 
     @Override
+    public List<Long> findDayLogIdsByTripId(final Long tripId) {
+        final String sql = """
+                SELECT d.id
+                FROM day_log d
+                WHERE d.trip_id = :tripId
+                """;
+        final MapSqlParameterSource parameters = new MapSqlParameterSource();
+        parameters.addValue("tripId", tripId);
+        return namedParameterJdbcTemplate.queryForList(sql, parameters, Long.class);
+    }
+
+    @Override
     public List<Long> findDayLogIdsByTripIds(final List<Long> tripIds) {
         final String sql = """
                 SELECT d.id

--- a/backend/src/test/java/hanglog/trip/service/TripServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/TripServiceTest.java
@@ -188,8 +188,7 @@ class TripServiceTest {
         // given
         final Long invalidTripId = 2L;
 
-        given(tripRepository.findById(invalidTripId))
-                .willThrow(new BadRequestException(NOT_FOUND_TRIP_ID));
+        given(tripRepository.existsById(invalidTripId)).willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> tripService.delete(invalidTripId))


### PR DESCRIPTION
## 📄 Summary
 #688  
- 단일 여행 삭제 쿼리 개선
- 아이템 삭제 쿼리 개선

## 🙋🏻 More

세부 결과는 노션 StudyLog의 삭제쿼리개선 참고

### 1. 단일여행 삭제 쿼리 개선

**queryCounts=3731 -> queryCounts=14**
> 실험 대상: day 60일, item 각 day당 20개, 각 item에 spot, expense 포함 (이미지 포함x)

개선 전
<img width="931" alt="image" src="https://github.com/woowacourse-teams/2023-hang-log/assets/49433615/d4559d88-528f-46f0-9b41-67f5b5c53a4b">

개선 후
![image](https://github.com/woowacourse-teams/2023-hang-log/assets/49433615/0bcd9353-3561-43ce-8e87-6e0ab3741d4f)

### 2. 아이템 삭제 쿼리 개선

**queryCounts=14 -> queryCounts=7**
> 실험 대상: 장소, 경비, 이미지 5장 포함된 item


개선 전
![image](https://github.com/woowacourse-teams/2023-hang-log/assets/49433615/981e9677-5268-4385-afa7-5cdc808df66b)

개선 후
멤버검증 2 + item 조회 1 + image, place, expense 각각 있으면 1 (없으면 0) + item 삭제 1
![image](https://github.com/woowacourse-teams/2023-hang-log/assets/49433615/ca94fda4-3ee9-487e-bafa-7fd81b47e24a)
![image](https://github.com/woowacourse-teams/2023-hang-log/assets/49433615/cb32e89c-66a3-44a4-ac1c-916fe7650c76)

