### PR TITLE
아이템 수정 & 데이로그 수정 & 아이템 oridinal 수정 재업로드

### DIFF
--- a/backend/src/main/java/hanglog/category/domain/Category.java
+++ b/backend/src/main/java/hanglog/category/domain/Category.java
@@ -6,6 +6,7 @@ import hanglog.global.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,4 +29,21 @@ public class Category extends BaseEntity {
 
     @Column(nullable = false, length = 50)
     private String korName;
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Category category)) {
+            return false;
+        }
+        return Objects.equals(id, category.id) && Objects.equals(engName, category.engName)
+                && Objects.equals(korName, category.korName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, engName, korName);
+    }
 }

--- a/backend/src/main/java/hanglog/expense/domain/Expense.java
+++ b/backend/src/main/java/hanglog/expense/domain/Expense.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -58,5 +59,22 @@ public class Expense extends BaseEntity {
             final Category category
     ) {
         this(null, currency, amount, category);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Expense expense)) {
+            return false;
+        }
+        return Objects.equals(currency, expense.currency) && Objects.equals(amount, expense.amount)
+                && Objects.equals(category, expense.category);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currency, amount, category);
     }
 }

--- a/backend/src/main/java/hanglog/image/domain/Image.java
+++ b/backend/src/main/java/hanglog/image/domain/Image.java
@@ -1,6 +1,5 @@
 package hanglog.image.domain;
 
-import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -32,7 +31,7 @@ public class Image extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
-    @ManyToOne(fetch = LAZY, cascade = {PERSIST})
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
 

--- a/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepository.java
+++ b/backend/src/main/java/hanglog/image/domain/repository/CustomImageRepository.java
@@ -1,0 +1,11 @@
+package hanglog.image.domain.repository;
+
+import hanglog.image.domain.Image;
+import java.util.List;
+
+public interface CustomImageRepository {
+
+    void saveAll(final List<Image> images);
+
+    void deleteAll(final List<Image> images);
+}

--- a/backend/src/main/java/hanglog/image/infrastructure/CustomImageRepositoryImpl.java
+++ b/backend/src/main/java/hanglog/image/infrastructure/CustomImageRepositoryImpl.java
@@ -1,0 +1,58 @@
+package hanglog.image.infrastructure;
+
+import hanglog.image.domain.Image;
+import hanglog.image.domain.repository.CustomImageRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CustomImageRepositoryImpl implements CustomImageRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public void saveAll(final List<Image> images) {
+        final String sql = """
+                    INSERT INTO image (created_at, modified_at, item_id, name, status) 
+                    VALUES (:createdAt, :modifiedAt, :itemId, :name, :status)
+                """;
+        namedParameterJdbcTemplate.batchUpdate(sql, getImageToSqlParameterSources(images));
+    }
+
+    @Override
+    public void deleteAll(final List<Image> images) {
+        final String sql = """
+                    DELETE FROM image WHERE id IN (:imageIds)
+                """;
+        namedParameterJdbcTemplate.update(sql, getDeletedImageIdsSqlParameterSources(images));
+    }
+
+    private SqlParameterSource getDeletedImageIdsSqlParameterSources(final List<Image> images) {
+        final List<Long> imageIds = images.stream()
+                .map(Image::getId)
+                .toList();
+        return new MapSqlParameterSource("imageIds", imageIds);
+    }
+
+    private MapSqlParameterSource[] getImageToSqlParameterSources(final List<Image> images) {
+        return images.stream()
+                .map(this::getImageToSqlParameterSource)
+                .toArray(MapSqlParameterSource[]::new);
+    }
+
+    private MapSqlParameterSource getImageToSqlParameterSource(final Image image) {
+        final LocalDateTime now = LocalDateTime.now();
+        return new MapSqlParameterSource()
+                .addValue("createdAt", now)
+                .addValue("modifiedAt", now)
+                .addValue("itemId", image.getItem().getId())
+                .addValue("name", image.getName())
+                .addValue("status", image.getStatus().name());
+    }
+}

--- a/backend/src/main/java/hanglog/trip/domain/Item.java
+++ b/backend/src/main/java/hanglog/trip/domain/Item.java
@@ -4,7 +4,6 @@ import static hanglog.global.exception.ExceptionCode.INVALID_EXPENSE_OVER_MAX;
 import static hanglog.global.exception.ExceptionCode.INVALID_EXPENSE_UNDER_MIN;
 import static hanglog.global.exception.ExceptionCode.INVALID_RATING;
 import static hanglog.global.type.StatusType.USABLE;
-import static jakarta.persistence.CascadeType.MERGE;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.EnumType.STRING;
@@ -68,19 +67,19 @@ public class Item extends BaseEntity {
 
     private String memo;
 
-    @OneToOne(fetch = LAZY, cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
+    @OneToOne(fetch = LAZY, cascade = REMOVE)
     @JoinColumn(name = "place_id")
     private Place place;
 
-    @ManyToOne(fetch = LAZY, cascade = {PERSIST})
+    @ManyToOne(fetch = LAZY, cascade = PERSIST)
     @JoinColumn(name = "day_log_id", nullable = false)
     private DayLog dayLog;
 
-    @OneToOne(fetch = LAZY, cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
+    @OneToOne(fetch = LAZY, cascade = REMOVE)
     @JoinColumn(name = "expense_id")
     private Expense expense;
 
-    @OneToMany(mappedBy = "item", fetch = LAZY, cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
+    @OneToMany(mappedBy = "item", fetch = LAZY, cascade = REMOVE)
     private List<Image> images = new ArrayList<>();
 
     public Item(
@@ -197,5 +196,9 @@ public class Item extends BaseEntity {
 
     public void changeOrdinal(final int ordinal) {
         this.ordinal = ordinal;
+    }
+
+    public boolean isSpot() {
+        return itemType.isSpot();
     }
 }

--- a/backend/src/main/java/hanglog/trip/domain/Place.java
+++ b/backend/src/main/java/hanglog/trip/domain/Place.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.math.BigDecimal;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,5 +55,23 @@ public class Place extends BaseEntity {
         this.latitude = latitude;
         this.longitude = longitude;
         this.category = category;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Place place)) {
+            return false;
+        }
+        return Objects.equals(name, place.name) && Objects.equals(latitude, place.latitude)
+                && Objects.equals(longitude, place.longitude) && Objects.equals(category,
+                place.category);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, latitude, longitude, category);
     }
 }

--- a/backend/src/main/java/hanglog/trip/domain/repository/CustomItemRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/CustomItemRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface CustomItemRepository {
 
     List<ItemElement> findItemIdsByDayLogIds(final List<Long> dayLogIds);
+
+    void updateOrdinals(final List<Long> orderedItemIds);
 }

--- a/backend/src/main/java/hanglog/trip/domain/repository/DayLogRepository.java
+++ b/backend/src/main/java/hanglog/trip/domain/repository/DayLogRepository.java
@@ -2,12 +2,34 @@ package hanglog.trip.domain.repository;
 
 import hanglog.trip.domain.DayLog;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface DayLogRepository extends JpaRepository<DayLog, Long> {
+
+    @Query("""
+            SELECT dayLog
+            FROM DayLog dayLog
+            LEFT JOIN FETCH dayLog.items items
+            WHERE dayLog.id = :dayLogId
+            """)
+    Optional<DayLog> findWithItemsById(@Param("dayLogId") final Long dayLogId);
+
+    @Query("""
+            SELECT dayLog
+            FROM DayLog dayLog
+            LEFT JOIN FETCH dayLog.items items
+            LEFT JOIN FETCH items.images images
+            LEFT JOIN FETCH items.expense expense
+            LEFT JOIN FETCH items.place place
+            LEFT JOIN FETCH expense.category expense_category
+            LEFT JOIN FETCH place.category place_category
+            WHERE dayLog.id = :dayLogId
+            """)
+    Optional<DayLog> findWithItemDetailsById(@Param("dayLogId") final Long dayLogId);
 
     @Modifying
     @Query("""

--- a/backend/src/main/java/hanglog/trip/infrastructure/CustomItemRepositoryImpl.java
+++ b/backend/src/main/java/hanglog/trip/infrastructure/CustomItemRepositoryImpl.java
@@ -2,12 +2,15 @@ package hanglog.trip.infrastructure;
 
 import hanglog.trip.domain.repository.CustomItemRepository;
 import hanglog.trip.dto.ItemElement;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -33,5 +36,25 @@ public class CustomItemRepositoryImpl implements CustomItemRepository {
         final MapSqlParameterSource parameters = new MapSqlParameterSource();
         parameters.addValue("dayLogIds", dayLogIds);
         return namedParameterJdbcTemplate.query(sql, parameters, elementRowMapper);
+    }
+
+    @Override
+    public void updateOrdinals(final List<Long> orderedItemIds) {
+        final String sql = "UPDATE item SET ordinal = :newOrdinal WHERE id = :itemId";
+        final SqlParameterSource[] sqlParameterSources = getUpdateOrdinalsSqlParameterSources(orderedItemIds);
+        namedParameterJdbcTemplate.batchUpdate(sql, sqlParameterSources);
+    }
+
+    private SqlParameterSource[] getUpdateOrdinalsSqlParameterSources(final List<Long> orderedItemIds) {
+        final SqlParameterSource[] sqlParameterSources = new MapSqlParameterSource[orderedItemIds.size()];
+        for (int i = 0; i < orderedItemIds.size(); i++) {
+            final Long itemId = orderedItemIds.get(i);
+            final int newOrdinal = i + 1;
+            final Map<String, Object> sqlParameterSource = new HashMap<>();
+            sqlParameterSource.put("newOrdinal", newOrdinal);
+            sqlParameterSource.put("itemId", itemId);
+            sqlParameterSources[i] = new MapSqlParameterSource(sqlParameterSource);
+        }
+        return sqlParameterSources;
     }
 }

--- a/backend/src/test/java/hanglog/integration/controller/ItemIntegrationTest.java
+++ b/backend/src/test/java/hanglog/integration/controller/ItemIntegrationTest.java
@@ -156,9 +156,9 @@ class ItemIntegrationTest extends IntegrationTest {
         );
     }
 
-    @DisplayName("NonSpot인 아이템을 Spot으로 수정한다.")
+    @DisplayName("Spot인 아이템을 NonSpot으로 수정한다.")
     @Test
-    void updateItem_NonSpotToSpot() {
+    void updateItem_SpotToNonSpot() {
         // when
         final ItemRequest itemRequest = getSpotItemRequest();
         final ExtractableResponse<Response> createResponse = requestCreateItem(memberTokens, tripId, itemRequest);
@@ -239,9 +239,9 @@ class ItemIntegrationTest extends IntegrationTest {
         );
     }
 
-    @DisplayName("Spot에서 NonSpot으로 수정한다.")
+    @DisplayName("NonSpot에서 Spot으로 수정한다.")
     @Test
-    void updateItem_SpotToNonSpot() {
+    void updateItem_NonSpotToSpot() {
         // when
         final ItemRequest itemRequest = getNonSpotItemRequest();
         final ExtractableResponse<Response> createResponse = requestCreateItem(memberTokens, tripId, itemRequest);
@@ -254,7 +254,7 @@ class ItemIntegrationTest extends IntegrationTest {
                 "updated memo",
                 dayLogId,
                 List.of("test1.png", "test2.png"),
-                false,
+                true,
                 getPlaceRequest(),
                 getExpenseRequest()
         );

--- a/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/DayLogServiceTest.java
@@ -4,15 +4,13 @@ import static hanglog.trip.fixture.DayLogFixture.LONDON_DAYLOG_1;
 import static hanglog.trip.fixture.DayLogFixture.UPDATED_LONDON_DAYLOG;
 import static hanglog.trip.fixture.ItemFixture.DAYLOG_FOR_ITEM_FIXTURE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import hanglog.trip.domain.DayLog;
-import hanglog.trip.domain.Item;
+import hanglog.trip.domain.repository.CustomItemRepository;
 import hanglog.trip.domain.repository.DayLogRepository;
-import hanglog.trip.domain.repository.ItemRepository;
 import hanglog.trip.dto.request.DayLogUpdateTitleRequest;
 import hanglog.trip.dto.request.ItemsOrdinalUpdateRequest;
 import hanglog.trip.dto.response.DayLogResponse;
@@ -36,7 +34,7 @@ class DayLogServiceTest {
     private DayLogRepository dayLogRepository;
 
     @Mock
-    private ItemRepository itemRepository;
+    private CustomItemRepository customItemRepository;
 
     @DisplayName("날짜별 여행을 조회할 수 있다.")
     @Test
@@ -65,7 +63,7 @@ class DayLogServiceTest {
         // given
         final DayLogUpdateTitleRequest request = new DayLogUpdateTitleRequest("updated");
 
-        given(dayLogRepository.findById(1L))
+        given(dayLogRepository.findWithItemsById(1L))
                 .willReturn(Optional.of(LONDON_DAYLOG_1));
         given(dayLogRepository.save(any(DayLog.class)))
                 .willReturn(UPDATED_LONDON_DAYLOG);
@@ -74,7 +72,7 @@ class DayLogServiceTest {
         dayLogService.updateTitle(LONDON_DAYLOG_1.getId(), request);
 
         // then
-        verify(dayLogRepository).findById(UPDATED_LONDON_DAYLOG.getId());
+        verify(dayLogRepository).findWithItemsById(UPDATED_LONDON_DAYLOG.getId());
         verify(dayLogRepository).save(any(DayLog.class));
     }
 
@@ -83,27 +81,13 @@ class DayLogServiceTest {
     void updateItemOrdinals() {
         // given
         final ItemsOrdinalUpdateRequest request = new ItemsOrdinalUpdateRequest(List.of(4L, 3L, 2L, 1L));
-        given(dayLogRepository.findById(1L))
+        given(dayLogRepository.findWithItemsById(1L))
                 .willReturn(Optional.of(DAYLOG_FOR_ITEM_FIXTURE));
-        given(itemRepository.findById(1L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(0)));
-        given(itemRepository.findById(2L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(1)));
-        given(itemRepository.findById(3L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(2)));
-        given(itemRepository.findById(4L))
-                .willReturn(Optional.ofNullable(DAYLOG_FOR_ITEM_FIXTURE.getItems().get(3)));
 
         // when
         dayLogService.updateOrdinalOfItems(1L, request);
 
         // then
-        final List<Item> items = DAYLOG_FOR_ITEM_FIXTURE.getItems();
-        assertSoftly(softly -> {
-            softly.assertThat(items.get(0).getOrdinal()).isEqualTo(4);
-            softly.assertThat(items.get(1).getOrdinal()).isEqualTo(3);
-            softly.assertThat(items.get(2).getOrdinal()).isEqualTo(2);
-            softly.assertThat(items.get(3).getOrdinal()).isEqualTo(1);
-        });
+        verify(customItemRepository).updateOrdinals(any());
     }
 }

--- a/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
+++ b/backend/src/test/java/hanglog/trip/service/ItemServiceTest.java
@@ -5,17 +5,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
 import hanglog.category.domain.Category;
 import hanglog.category.domain.repository.CategoryRepository;
 import hanglog.category.fixture.CategoryFixture;
+import hanglog.expense.domain.repository.ExpenseRepository;
 import hanglog.global.exception.BadRequestException;
+import hanglog.image.domain.repository.CustomImageRepository;
 import hanglog.image.domain.repository.ImageRepository;
 import hanglog.trip.domain.DayLog;
 import hanglog.trip.domain.Item;
 import hanglog.trip.domain.repository.DayLogRepository;
 import hanglog.trip.domain.repository.ItemRepository;
+import hanglog.trip.domain.repository.PlaceRepository;
 import hanglog.trip.domain.type.ItemType;
 import hanglog.trip.dto.request.ExpenseRequest;
 import hanglog.trip.dto.request.ItemRequest;
@@ -43,6 +47,15 @@ class ItemServiceTest {
 
     @Mock
     private ItemRepository itemRepository;
+
+    @Mock
+    private CustomImageRepository customImageRepository;
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private ExpenseRepository expenseRepository;
 
     @Mock
     private CategoryRepository categoryRepository;
@@ -77,10 +90,11 @@ class ItemServiceTest {
 
         given(itemRepository.save(any()))
                 .willReturn(ItemFixture.LONDON_EYE_ITEM);
-        given(dayLogRepository.findById(any()))
+        given(dayLogRepository.findWithItemsById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
         given(categoryRepository.findById(any()))
                 .willReturn(Optional.of(new Category(1L, "문화", "culture")));
+        doNothing().when(customImageRepository).saveAll(any());
 
         // when
         final Long actualId = itemService.save(1L, itemRequest);
@@ -112,7 +126,7 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(dayLogRepository.findById(any()))
+        given(dayLogRepository.findWithItemsById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
 
         // when & then
@@ -141,7 +155,7 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(dayLogRepository.findById(any()))
+        given(dayLogRepository.findWithItemsById(any()))
                 .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
 
         // when & then
@@ -164,15 +178,13 @@ class ItemServiceTest {
                 null,
                 expenseRequest
         );
+        final DayLog dayLog = new DayLog("첫날", 1, TripFixture.LONDON_TRIP);
+        dayLog.addItem(ItemFixture.LONDON_EYE_ITEM);
 
-        given(itemRepository.save(any()))
-                .willReturn(ItemFixture.LONDON_EYE_ITEM);
-        given(itemRepository.findById(any()))
-                .willReturn(Optional.of(ItemFixture.LONDON_EYE_ITEM));
         given(categoryRepository.findById(any()))
                 .willReturn(Optional.of(CategoryFixture.EXPENSE_CATEGORIES.get(1)));
-        given(dayLogRepository.findById(any()))
-                .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
+        given(dayLogRepository.findWithItemDetailsById(any()))
+                .willReturn(Optional.of(dayLog));
 
         // when
         itemService.update(1L, 1L, itemUpdateRequest);
@@ -204,14 +216,12 @@ class ItemServiceTest {
                 expenseRequest
         );
 
-        given(itemRepository.save(any()))
-                .willReturn(ItemFixture.LONDON_EYE_ITEM);
-        given(itemRepository.findById(any()))
-                .willReturn(Optional.of(ItemFixture.LONDON_EYE_ITEM));
+        final DayLog dayLog = new DayLog("첫날", 1, TripFixture.LONDON_TRIP);
+        dayLog.addItem(ItemFixture.LONDON_EYE_ITEM);
         given(categoryRepository.findById(any()))
                 .willReturn(Optional.of(CategoryFixture.EXPENSE_CATEGORIES.get(1)));
-        given(dayLogRepository.findById(any()))
-                .willReturn(Optional.of(new DayLog("첫날", 1, TripFixture.LONDON_TRIP)));
+        given(dayLogRepository.findWithItemDetailsById(any()))
+                .willReturn(Optional.of(dayLog));
 
         // when
         itemService.update(1L, 1L, itemUpdateRequest);
@@ -246,7 +256,7 @@ class ItemServiceTest {
         itemService.delete(itemForDelete.getId());
 
         // then
-        verify(itemRepository).delete(any());
+        verify(itemRepository).deleteById(any());
     }
 
     @DisplayName("모든 여행 아이템의 Response를 반환한다.")


### PR DESCRIPTION
## 📄 Summary
>
[이전 PR](https://github.com/woowacourse-teams/2023-hang-log/pull/693)
아이템 수정 로직 좀 더 가독성있게 수정함. (근데 아직도 가독성 좋은 지 잘 모르겠음) [커밋](https://github.com/woowacourse-teams/2023-hang-log/pull/710/commits/73be3a0954e88af876fc56102b53d99bbeb15302)

아이템의 Place, Expense, Image의 수정 로직을 아래의 플로우로 통일 (`originalObject` : 변경 요청전의 오브젝트)
* isNotUpdated이면 `originalObject`사용
* deleteNotUsedObject : 더 이상 사용하지 않는 originalObject를 DB에서 삭제
* saveNewlyUpdatedObject : 변경된 오브젝트를 DB에 저장

## 🙋🏻 More
> 라온... Item 생성자 리팩토링은... 그... 나중에 따로 PR 파서 합시다... 😂
