### PR TITLE
이미지 업로드 수정

### DIFF
--- a/backend/src/main/java/hanglog/image/infrastructure/ImageUploader.java
+++ b/backend/src/main/java/hanglog/image/infrastructure/ImageUploader.java
@@ -8,13 +8,11 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import hanglog.global.exception.ImageException;
 import hanglog.image.domain.ImageFile;
-import hanglog.image.domain.S3ImageEvent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -24,7 +22,6 @@ public class ImageUploader {
     private static final String CACHE_CONTROL_VALUE = "max-age=3153600";
 
     private final AmazonS3 s3Client;
-    private final ApplicationEventPublisher publisher;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -33,14 +30,9 @@ public class ImageUploader {
     private String folder;
 
     public List<String> uploadImages(final List<ImageFile> imageFiles) {
-        try {
-            return imageFiles.stream()
-                    .map(this::uploadImage)
-                    .toList();
-        } catch (final ImageException e) {
-            imageFiles.forEach(imageFile -> publisher.publishEvent(new S3ImageEvent(imageFile.getHashedName())));
-            throw e;
-        }
+        return imageFiles.stream()
+                .map(this::uploadImage)
+                .toList();
     }
 
     private String uploadImage(final ImageFile imageFile) {

--- a/backend/src/main/java/hanglog/image/infrastructure/ImageUploader.java
+++ b/backend/src/main/java/hanglog/image/infrastructure/ImageUploader.java
@@ -8,11 +8,13 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import hanglog.global.exception.ImageException;
 import hanglog.image.domain.ImageFile;
+import hanglog.image.domain.S3ImageEvent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,6 +24,7 @@ public class ImageUploader {
     private static final String CACHE_CONTROL_VALUE = "max-age=3153600";
 
     private final AmazonS3 s3Client;
+    private final ApplicationEventPublisher publisher;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -30,9 +33,14 @@ public class ImageUploader {
     private String folder;
 
     public List<String> uploadImages(final List<ImageFile> imageFiles) {
-        return imageFiles.stream()
-                .map(this::uploadImage)
-                .toList();
+        try {
+            return imageFiles.stream()
+                    .map(this::uploadImage)
+                    .toList();
+        } catch (final ImageException e) {
+            imageFiles.forEach(imageFile -> publisher.publishEvent(new S3ImageEvent(imageFile.getHashedName())));
+            throw e;
+        }
     }
 
     private String uploadImage(final ImageFile imageFile) {

--- a/backend/src/main/java/hanglog/trip/service/ImageService.java
+++ b/backend/src/main/java/hanglog/trip/service/ImageService.java
@@ -6,7 +6,6 @@ import static hanglog.global.exception.ExceptionCode.EXCEED_IMAGE_LIST_SIZE;
 import hanglog.global.exception.ImageException;
 import hanglog.image.domain.ImageFile;
 import hanglog.image.domain.S3ImageEvent;
-import hanglog.image.dto.ImagesResponse;
 import hanglog.image.infrastructure.ImageUploader;
 import hanglog.trip.dto.response.ImagesResponse;
 import java.util.List;


### PR DESCRIPTION
## 📄 Summary
> close #716

굉장히 귀여운 PR 등장~ 코드 +5줄~
기존에 아이템 이미지들을 S3에 업로드하다가 예외가 발생하면, 예외가 발생하기 전에 업로드된 이미지들은 S3에 그대로 남아있었습니다.
S3 업로드시 예외가 발생하면 `S3ImageEvent`를 발행해, 요청으로 온 모든 이미지들을  S3에서 삭제하게 했습니다. (요청으로 온 이미지들중 업로드가 된 이미지들만 특정해서 지울 수도 있지만, 아이템당 최대 5개의 이미지만 가지기에 그냥 전부 삭제하게 했습니다. S3에 존재하지 않는 이미지를 삭제하는 요청이 간다면 무시되기에 괜찮다고 생각했음)


### 원래 하려고 했던 것...
S3 이미지 삭제를 `@Async`를 사용해 비동기로 처리하고 있습니다. `@Async`만 붙이면 요청 수만큼 thread를 생성하는 `SimpleAsyncTaskExecutor`를 쓰는 줄 알고 thread pool size 지정해주려고 했는데, 스프링부트에서는  `@Async` 만 해도 `ThreadPoolTaskExecutor`를 잘 가져오네요!!!ㅎㅎ (디폴트값인 core pool size 8 적용중)

core pool size라도 튜닝할까 했는데, 몇으로 해야할 지 잘 모르겠어요 ㅎㅎ 😥 어떤 걸 기준으로 잡고 thread를 설정해야 할지...............ㅎㅎ 의견이 있으시다면 코멘트로 남겨주십시오

* 20KB * 100개의 이미지를 삭제할 때 350ms정도 소요 (데이터 더 추가해보겠)
* 이미지 삭제시 최악의 경우 6101번의 삭제 필요
* 여행하나당 평균 이미지 개수 5-6개정도(현재 데이터가 너무 적긴합니다 ㅋㅋ ㅠㅠ)




## 🙋🏻 More
>
