### PR TITLE
refactor: 잘못된 위치의 설정 수정

### DIFF
--- a/frontend-monorepo/frontend-monorepo.code-workspace
+++ b/frontend-monorepo/frontend-monorepo.code-workspace
@@ -14,12 +14,12 @@
       "**/dist": true,
       "**/node_modules": true,
       "tsconfig.tsbuildinfo": true
-    }
+    },
+    "eslint.nodePath": "../../.yarn/sdks",
+    "typescript.tsdk": "../../.yarn/sdks/typescript/lib",
+    "typescript.enablePromptUseWorkspaceTsdk": true,
+    "prettier.prettierPath": "../../.yarn/sdks/prettier/index.js",
   },
-  "eslint.nodePath": "../../.yarn/sdks",
-  "typescript.tsdk": "../.yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-  "prettier.prettierPath": "../../.yarn/sdks/prettier/index.js",
   "extensions": {
     "recommendations": [
       "arcanis.vscode-zipfs",


### PR DESCRIPTION
## 📄 Summary
> 주요 변경 사항은 'eslint.nodePath', 'typescript.tsdk', 'typescript.enablePromptUseWorkspaceTsdk', 그리고 'prettier.prettierPath' 설정들이 'settings' 객체 바깥에 위치하고 있었는데, 이를 'settings' 객체 안으로 옮겼습니다. 이 변경으로 인해 해당 설정들이 올바르게 인식될 수 있게 되었습니다.

## 🙋🏻 More
>
