### PR TITLE
refactor: Toggle 컴포넌트 재구축 및 서비스 코드 반영, 디자인시스템 v1.3.10 배포

### DIFF
--- a/frontend-monorepo/package.json
+++ b/frontend-monorepo/package.json
@@ -38,7 +38,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-config-standard-with-typescript": "^43.0.1",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.33.2",

--- a/frontend-monorepo/packages/hang-log-design-system/package.json
+++ b/frontend-monorepo/packages/hang-log-design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hang-log-design-system",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "행록 디자인 시스템",
   "homepage": "https://github.com/hang-log-design-system/design-system",
   "main": "dist/index.js",

--- a/frontend-monorepo/packages/hang-log-design-system/package.json
+++ b/frontend-monorepo/packages/hang-log-design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hang-log-design-system",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "행록 디자인 시스템",
   "homepage": "https://github.com/hang-log-design-system/design-system",
   "main": "dist/index.js",

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/Item.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/Item.tsx
@@ -1,0 +1,23 @@
+import type { ForwardedRef, PropsWithChildren } from 'react';
+import { useContext, forwardRef } from 'react';
+import { NewToggleContext } from '@components/NewToggle/NewToggle';
+
+export interface ItemProps extends PropsWithChildren {
+  toggleKey: number | string;
+}
+
+const ToggleItem = ({ children, toggleKey }: ItemProps, ref?: ForwardedRef<HTMLDivElement>) => {
+  const context = useContext(NewToggleContext);
+
+  if (!context) throw new Error('NewToggle 컴포넌트가 Wrapping되어있지 않습니다.');
+
+  const { selectKey } = context;
+
+  return (
+    <div ref={ref} style={{ display: selectKey === toggleKey ? 'block' : 'none' }}>
+      {children}
+    </div>
+  );
+};
+
+export default forwardRef(ToggleItem);

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/List.style.ts
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/List.style.ts
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+
+import { Theme } from '@styles/Theme';
+
+export const getListStyling = (isSelected: boolean) =>
+  css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+
+    padding: '8px 12px',
+    border: `1px solid ${isSelected ? Theme.color.blue700 : Theme.color.gray200}`,
+
+    backgroundColor: isSelected ? Theme.color.blue100 : Theme.color.white,
+
+    fontSize: Theme.text.small.fontSize,
+    lineHeight: Theme.text.small.lineHeight,
+    color: isSelected ? Theme.color.blue700 : Theme.color.gray600,
+
+    transition: `all .2s ease-in`,
+
+    cursor: 'pointer',
+
+    '&:hover': {
+      color: isSelected ? Theme.color.blue700 : Theme.color.gray700,
+      backgroundColor: isSelected ? Theme.color.blue200 : Theme.color.gray100,
+    },
+  });

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/List.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/List.tsx
@@ -1,8 +1,8 @@
 import type { ComponentPropsWithRef, ForwardedRef, KeyboardEvent } from 'react';
 import { useContext, forwardRef } from 'react';
 
-import { getListStyling } from '@components/NewToggle/List.style';
-import { NewToggleContext } from './NewToggle';
+import { getListStyling } from '@components/NewToggle/Toggle.style';
+import { NewToggleContext } from '@components/NewToggle/NewToggle';
 
 export interface ToggleProps extends ComponentPropsWithRef<'li'> {
   toggleKey: number | string;

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/List.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/List.tsx
@@ -1,0 +1,48 @@
+import type { ComponentPropsWithRef, ForwardedRef, KeyboardEvent } from 'react';
+import { useContext, forwardRef } from 'react';
+
+import { getListStyling } from '@components/NewToggle/List.style';
+import { NewToggleContext } from './NewToggle';
+
+export interface ToggleProps extends ComponentPropsWithRef<'li'> {
+  toggleKey: number | string;
+  text: string;
+}
+
+const List = (
+  { toggleKey, text, ...attributes }: ToggleProps,
+  ref?: ForwardedRef<HTMLLIElement>
+) => {
+  const context = useContext(NewToggleContext);
+
+  if (!context) throw new Error('NewToggle 컴포넌트가 Wrapping되어있지 않습니다.');
+
+  const { selectKey, handleSelect } = context;
+
+  const handleEnterKeyPress = (event: KeyboardEvent<HTMLLIElement>) => {
+    if (event.key === 'Enter') {
+      handleSelect(toggleKey);
+    }
+  };
+
+  return (
+    <li
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+      role="radio"
+      aria-label={`${text}로 토글할 수 있는 버튼입니다. ${
+        selectKey === toggleKey ? '이미 선택되어있습니다.' : ''
+      }`}
+      tabIndex={0}
+      ref={ref}
+      css={getListStyling(selectKey === toggleKey)}
+      aria-checked={selectKey === toggleKey}
+      onClick={() => handleSelect(toggleKey)}
+      onKeyDown={handleEnterKeyPress}
+      {...attributes}
+    >
+      {text}
+    </li>
+  );
+};
+
+export default forwardRef(List);

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/NewToggle.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/NewToggle.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState, useMemo, createContext } from 'react';
 import List from '@components/NewToggle/List';
 import Item from '@components/NewToggle/Item';
 import { flushSync } from 'react-dom';
+import { getToggleWrapperStyling } from '@components/NewToggle/Toggle.style';
 
 interface ToggleContextType {
   selectKey: number | string;
@@ -35,7 +36,11 @@ const NewToggle = ({ initialSelect = 0, additinalFunc, children }: NewToggleProp
     [handleSelect, selected]
   );
 
-  return <NewToggleContext.Provider value={context}>{children}</NewToggleContext.Provider>;
+  return (
+    <NewToggleContext.Provider value={context}>
+      <div css={getToggleWrapperStyling}>{children}</div>
+    </NewToggleContext.Provider>
+  );
 };
 
 NewToggle.List = List;

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/NewToggle.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/NewToggle.tsx
@@ -1,0 +1,35 @@
+import type { PropsWithChildren } from 'react';
+import { useMemo, createContext } from 'react';
+import { useSelect } from '@hooks/useSelect';
+import List from '@components/NewToggle/List';
+import Item from '@components/NewToggle/Item';
+
+interface ToggleContextType {
+  selectKey: number | string;
+  handleSelect: (selectedId: number | string) => void;
+}
+
+export interface NewToggleProps extends PropsWithChildren {
+  initialSelect?: number | string;
+}
+
+export const NewToggleContext = createContext<ToggleContextType | null>(null);
+
+const NewToggle = ({ initialSelect = 0, children }: NewToggleProps) => {
+  const { selected, handleSelectClick } = useSelect(initialSelect);
+
+  const context = useMemo(
+    () => ({
+      selectKey: selected,
+      handleSelect: handleSelectClick,
+    }),
+    [handleSelectClick, selected]
+  );
+
+  return <NewToggleContext.Provider value={context}>{children}</NewToggleContext.Provider>;
+};
+
+NewToggle.List = List;
+NewToggle.Item = Item;
+
+export default NewToggle;

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/NewToggle.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/NewToggle.tsx
@@ -1,8 +1,8 @@
 import type { PropsWithChildren } from 'react';
-import { useMemo, createContext } from 'react';
-import { useSelect } from '@hooks/useSelect';
+import { useCallback, useState, useMemo, createContext } from 'react';
 import List from '@components/NewToggle/List';
 import Item from '@components/NewToggle/Item';
+import { flushSync } from 'react-dom';
 
 interface ToggleContextType {
   selectKey: number | string;
@@ -11,19 +11,28 @@ interface ToggleContextType {
 
 export interface NewToggleProps extends PropsWithChildren {
   initialSelect?: number | string;
+  additinalFunc?: (key: number | string) => void;
 }
 
 export const NewToggleContext = createContext<ToggleContextType | null>(null);
 
-const NewToggle = ({ initialSelect = 0, children }: NewToggleProps) => {
-  const { selected, handleSelectClick } = useSelect(initialSelect);
+const NewToggle = ({ initialSelect = 0, additinalFunc, children }: NewToggleProps) => {
+  const [selected, setSelected] = useState<number | string>(initialSelect);
+
+  const handleSelect = useCallback(
+    (select: number | string) => {
+      flushSync(() => setSelected(select));
+      if (additinalFunc) additinalFunc(select);
+    },
+    [additinalFunc]
+  );
 
   const context = useMemo(
     () => ({
       selectKey: selected,
-      handleSelect: handleSelectClick,
+      handleSelect,
     }),
-    [handleSelectClick, selected]
+    [handleSelect, selected]
   );
 
   return <NewToggleContext.Provider value={context}>{children}</NewToggleContext.Provider>;

--- a/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/Toggle.style.ts
+++ b/frontend-monorepo/packages/hang-log-design-system/src/components/NewToggle/Toggle.style.ts
@@ -26,3 +26,20 @@ export const getListStyling = (isSelected: boolean) =>
       backgroundColor: isSelected ? Theme.color.blue200 : Theme.color.gray100,
     },
   });
+
+export const getToggleWrapperStyling = css({
+  width: 'fit-content',
+  borderRadius: Theme.borderRadius.small,
+
+  overflow: 'hidden',
+
+  '& :first-of-type': {
+    borderTopLeftRadius: Theme.borderRadius.small,
+    borderBottomLeftRadius: Theme.borderRadius.small,
+  },
+
+  '& :last-of-type': {
+    borderTopRightRadius: Theme.borderRadius.small,
+    borderBottomRightRadius: Theme.borderRadius.small,
+  },
+});

--- a/frontend-monorepo/packages/hang-log-design-system/src/index.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/index.tsx
@@ -43,6 +43,7 @@ import Textarea from '@components/Textarea/Textarea';
 import Toast from '@components/Toast/Toast';
 import Toggle from '@components/Toggle/Toggle';
 import ToggleGroup from '@components/ToggleGroup/ToggleGroup';
+import NewToggle from '@components/NewToggle/NewToggle';
 
 import { Theme } from '@styles/Theme';
 
@@ -56,6 +57,7 @@ export {
   Badge,
   Box,
   SwitchToggle,
+  NewToggle,
   Button,
   Calendar,
   Carousel,

--- a/frontend-monorepo/packages/hang-log-design-system/src/stories/NewToggle.stories.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/stories/NewToggle.stories.tsx
@@ -1,0 +1,43 @@
+import { containerStyle } from '@stories/styles';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import NewToggle from '@components/NewToggle/NewToggle';
+
+const meta = {
+  title: 'NewToggle',
+  component: NewToggle,
+  args: {
+    initialSelect: 'toggle1',
+  },
+  argTypes: {
+    initialSelect: { control: 'string' },
+  },
+  decorators: [
+    (Story) => (
+      <ul css={containerStyle}>
+        <Story />
+      </ul>
+    ),
+  ],
+} satisfies Meta<typeof NewToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: ({ ...args }) => (
+    <NewToggle {...args}>
+      <h6>NewToggle</h6>
+      <div style={{ display: 'flex' }}>
+        <NewToggle.List text="Toggle 1" toggleKey="toggle1" />
+        <NewToggle.List text="Toggle 2" toggleKey="toggle2" />
+        <NewToggle.List text="Toggle 3" toggleKey="toggle3" />
+      </div>
+      <div>
+        <NewToggle.Item toggleKey="toggle1">나는토글1</NewToggle.Item>
+        <NewToggle.Item toggleKey="toggle2">나는토글2</NewToggle.Item>
+        <NewToggle.Item toggleKey="toggle3">나는토글3</NewToggle.Item>
+      </div>
+    </NewToggle>
+  ),
+};

--- a/frontend-monorepo/packages/hang-log-design-system/src/stories/NewToggle.stories.tsx
+++ b/frontend-monorepo/packages/hang-log-design-system/src/stories/NewToggle.stories.tsx
@@ -26,7 +26,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: ({ ...args }) => (
-    <NewToggle {...args}>
+    <NewToggle
+      {...args}
+      additinalFunc={(id: number | string) => {
+        // eslint-disable-next-line no-console
+        console.log(id);
+      }}
+    >
       <h6>NewToggle</h6>
       <div style={{ display: 'flex' }}>
         <NewToggle.List text="Toggle 1" toggleKey="toggle1" />

--- a/frontend-monorepo/packages/hanglog-service/package.json
+++ b/frontend-monorepo/packages/hanglog-service/package.json
@@ -44,7 +44,7 @@
     "axios": "^1.4.0",
     "browser-image-compression": "^2.0.2",
     "dotenv": "^16.3.1",
-    "hang-log-design-system": "^1.3.8",
+    "hang-log-design-system": "^1.3.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",

--- a/frontend-monorepo/packages/hanglog-service/public/mockServiceWorker.js
+++ b/frontend-monorepo/packages/hanglog-service/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.3.2).
+ * Mock Service Worker (1.2.3).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/frontend-monorepo/packages/hanglog-service/src/components/trips/TripsItemList/TripsItemList.tsx
+++ b/frontend-monorepo/packages/hanglog-service/src/components/trips/TripsItemList/TripsItemList.tsx
@@ -22,10 +22,6 @@ import { PATH } from '@constants/path';
 import { sortByNewest, sortByStartDate } from '@utils/sort';
 import { queryClient } from '@/hooks/api/queryClient';
 
-interface TripsItemListProps {
-  trips: TripsData[];
-}
-
 const TripsItemList = () => {
   const tripsData = queryClient.getQueryData(['trips']) as TripsData[];
 
@@ -36,7 +32,6 @@ const TripsItemList = () => {
         : tripsData?.slice().sort(sortByNewest);
 
     queryClient.setQueryData(['trips'], sortedTrips);
-    console.log(sortedTrips);
   };
 
   return (

--- a/frontend-monorepo/packages/hanglog-service/src/components/trips/TripsItemList/TripsItemList.tsx
+++ b/frontend-monorepo/packages/hanglog-service/src/components/trips/TripsItemList/TripsItemList.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
-import { Box, Button, Flex, Heading, Text, Toggle, ToggleGroup } from 'hang-log-design-system';
+import { Box, Button, Flex, Heading, Text, NewToggle as Toggle } from 'hang-log-design-system';
 
 import TripsItem from '@components/trips/TripsItem/TripsItem';
 import {
@@ -19,54 +19,62 @@ import type { TripsData } from '@type/trips';
 
 import { ORDER_BY_DATE, ORDER_BY_REGISTRATION } from '@constants/order';
 import { PATH } from '@constants/path';
+import { sortByNewest, sortByStartDate } from '@utils/sort';
+import { queryClient } from '@/hooks/api/queryClient';
 
 interface TripsItemListProps {
   trips: TripsData[];
-  order: string | number;
-  changeSelect: (selectedId: string | number) => void;
 }
 
-const TripsItemList = ({ trips, order, changeSelect }: TripsItemListProps) => {
+const TripsItemList = () => {
+  const tripsData = queryClient.getQueryData(['trips']) as TripsData[];
+
+  const handleSort = (select: number | string) => {
+    const sortedTrips =
+      select === ORDER_BY_DATE
+        ? tripsData?.slice().sort(sortByStartDate)
+        : tripsData?.slice().sort(sortByNewest);
+
+    queryClient.setQueryData(['trips'], sortedTrips);
+    console.log(sortedTrips);
+  };
+
   return (
     <section css={containerStyling}>
-      <Flex
-        tag="section"
-        styles={{ justify: 'right', paddingRight: '50px' }}
-        css={toggleGroupStyling}
-      >
-        <ToggleGroup>
-          <Toggle
+      <Toggle initialSelect={ORDER_BY_REGISTRATION} additinalFunc={handleSort}>
+        <Flex
+          tag="section"
+          styles={{ justify: 'right', paddingRight: '50px' }}
+          css={toggleGroupStyling}
+        >
+          <Toggle.List
             text={ORDER_BY_REGISTRATION}
-            toggleId={ORDER_BY_REGISTRATION}
-            selectedId={order}
-            changeSelect={changeSelect}
+            toggleKey={ORDER_BY_REGISTRATION}
             aria-label="등록순 정렬 버튼"
           />
-          <Toggle
+          <Toggle.List
             text={ORDER_BY_DATE}
-            toggleId={ORDER_BY_DATE}
-            selectedId={order}
-            changeSelect={changeSelect}
+            toggleKey={ORDER_BY_DATE}
             aria-label="날짜순 정렬 버튼"
           />
-        </ToggleGroup>
-      </Flex>
-      <Box tag="ol" css={gridBoxStyling}>
-        {trips.map((trip, index) => {
-          return (
-            <TripsItem
-              key={trip.id}
-              id={trip.id}
-              coverImage={trip.imageName}
-              cityTags={trip.cities}
-              itemName={trip.title}
-              duration={`${formatDate(trip.startDate)} - ${formatDate(trip.endDate)}`}
-              description={trip.description}
-              index={index}
-            />
-          );
-        })}
-      </Box>
+        </Flex>
+        <Box tag="ol" css={gridBoxStyling}>
+          {tripsData.map((trip, index) => {
+            return (
+              <TripsItem
+                key={trip.id}
+                id={trip.id}
+                coverImage={trip.imageName}
+                cityTags={trip.cities}
+                itemName={trip.title}
+                duration={`${formatDate(trip.startDate)} - ${formatDate(trip.endDate)}`}
+                description={trip.description}
+                index={index}
+              />
+            );
+          })}
+        </Box>
+      </Toggle>
     </section>
   );
 };

--- a/frontend-monorepo/packages/hanglog-service/src/pages/MyTripsPage/MyTripsPage.tsx
+++ b/frontend-monorepo/packages/hanglog-service/src/pages/MyTripsPage/MyTripsPage.tsx
@@ -17,26 +17,11 @@ import { PATH } from '@constants/path';
 const TripsPage = () => {
   const navigate = useNavigate();
   const { tripsData } = useTripsQuery();
-  const { selected: sortSelected, handleSelectClick: handleSortSelectClick } =
-    useSelect(ORDER_BY_REGISTRATION);
-
-  const sortedTrips =
-    sortSelected === ORDER_BY_DATE
-      ? tripsData?.slice().sort(sortByStartDate)
-      : tripsData?.slice().sort(sortByNewest);
 
   return (
     <>
       <TripsHeader />
-      {sortedTrips.length > 0 ? (
-        <TripsItemList
-          trips={sortedTrips}
-          order={sortSelected}
-          changeSelect={handleSortSelectClick}
-        />
-      ) : (
-        <TripsItemList.Empty />
-      )}
+      {tripsData.length > 0 ? <TripsItemList /> : <TripsItemList.Empty />}
       <FloatingButton css={addButtonStyling} onClick={() => navigate(PATH.CREATE_TRIP)} />
     </>
   );

--- a/frontend-monorepo/packages/hanglog-service/src/stories/trips/TripsItemList.stories.tsx
+++ b/frontend-monorepo/packages/hanglog-service/src/stories/trips/TripsItemList.stories.tsx
@@ -2,8 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import TripsItemList from '@components/trips/TripsItemList/TripsItemList';
 
-import { sortByStartDate } from '@utils/sort';
-
 import { trips } from '@mocks/data/myTrips';
 
 const meta = {
@@ -11,8 +9,6 @@ const meta = {
   component: TripsItemList,
   args: {
     trips,
-    order: '등록순',
-    changeSelect: () => {},
   },
 } satisfies Meta<typeof TripsItemList>;
 
@@ -23,6 +19,6 @@ export const SortByRegister: Story = {};
 
 export const SortByDate: Story = {
   render: ({ ...args }) => {
-    return <TripsItemList {...args} trips={trips?.slice().sort(sortByStartDate)} order="날짜순" />;
+    return <TripsItemList {...args} />;
   },
 };

--- a/frontend-monorepo/yarn.lock
+++ b/frontend-monorepo/yarn.lock
@@ -9840,7 +9840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-n@npm:^15.0.0 || ^16.0.0 , eslint-plugin-n@npm:^16.6.2":
+"eslint-plugin-n@npm:^15.0.0 || ^16.0.0 ":
   version: 16.6.2
   resolution: "eslint-plugin-n@npm:16.6.2"
   dependencies:
@@ -10720,7 +10720,7 @@ __metadata:
     eslint-config-prettier: "npm:^8.8.0"
     eslint-config-standard-with-typescript: "npm:^43.0.1"
     eslint-plugin-import: "npm:^2.29.1"
-    eslint-plugin-n: "npm:^16.6.2"
+    eslint-plugin-n: "npm:^15.0.0 || ^16.0.0 "
     eslint-plugin-prettier: "npm:4.0.0"
     eslint-plugin-promise: "npm:^6.1.1"
     eslint-plugin-react: "npm:^7.33.2"

--- a/frontend-monorepo/yarn.lock
+++ b/frontend-monorepo/yarn.lock
@@ -11280,7 +11280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hang-log-design-system@npm:^1.3.8, hang-log-design-system@workspace:packages/hang-log-design-system":
+"hang-log-design-system@npm:^1.3.8, hang-log-design-system@npm:^1.3.9, hang-log-design-system@workspace:packages/hang-log-design-system":
   version: 0.0.0-use.local
   resolution: "hang-log-design-system@workspace:packages/hang-log-design-system"
   dependencies:
@@ -11440,7 +11440,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^4.6.0"
     eslint-plugin-storybook: "npm:^0.6.13"
     fork-ts-checker-webpack-plugin: "npm:^9.0.0"
-    hang-log-design-system: "npm:^1.3.8"
+    hang-log-design-system: "npm:^1.3.9"
     html-webpack-plugin: "npm:^5.5.3"
     msw: "npm:^1.2.3"
     msw-storybook-addon: "npm:^1.8.0"


### PR DESCRIPTION
## 📄 Summary
> 기존 토글의 경우 사용하는 측에서 useSelect를 받아와 사용해야 했음. 
사용하는 측에서 컴포넌트가 너무 무거워지고 복잡해짐. 개선을 위한 재구축

기존 사용의 경우 아래와 같았음.
```ts
const { selected, handleSelectClick } = useSelect(ORDER_BY_REGISTRATION);
    // -> props로 내려줌

const 컴포넌트명 = ({selected, handleSelect}) =>{
return(
     <ToggleGroup>
         <Toggle selectedId={selected} changeSelect={handleSelect}>
         // ...
      </ToggleGroup>
}
```

개선 이후
```tsx
   <NewToggle additinalFunc={함수명} {...args}>
      <h6>NewToggle</h6>
      <div style={{ display: 'flex' }}>
        <NewToggle.List text="Toggle 1" toggleKey="toggle1" />
        <NewToggle.List text="Toggle 2" toggleKey="toggle2" />
      </div>
      <div>
        <NewToggle.Item toggleKey="toggle1">나는토글1</NewToggle.Item>
        <NewToggle.Item toggleKey="toggle2">나는토글2</NewToggle.Item>
      </div>
    </NewToggle>
```

이름은 기존 쓰고있던것들때문에 임시로 NewToggle로 해뒀습니다
NewToggle안에 additinalFunc는 내부적으로 변화하는 state에 의해 외부에서 컨트롤해야할 뭔가가 필요할때 쓰면 됩니다.

```ts
additinalFunc={(id: number | string) => {console.log(id)}} 
// 예시이긴 한데, id로 toggleKey가 들어온다고 생각하고 쓰면 됨
```


## 🙋🏻 More
> 일단 서비스측에서 사용하던 코드 가볍게 조금 고쳤는데, 추가적으로 고쳐갈 예정.

#792 