### PR TITLE
회원 탈퇴 시 bad SQL grammar 오류 발생 이슈 해결

### DIFF
--- a/backend/src/main/java/hanglog/login/service/LoginService.java
+++ b/backend/src/main/java/hanglog/login/service/LoginService.java
@@ -98,9 +98,13 @@ public class LoginService {
 
     public void deleteAccount(final Long memberId) {
         final List<Long> tripIds = customTripRepository.findTripIdsByMemberId(memberId);
-        publishedTripRepository.deleteByTripIds(tripIds);
-        sharedTripRepository.deleteByTripIds(tripIds);
+
+        if (!tripIds.isEmpty()) {
+            publishedTripRepository.deleteByTripIds(tripIds);
+            sharedTripRepository.deleteByTripIds(tripIds);
+            publisher.publishEvent(new MemberDeleteEvent(tripIds, memberId));
+        }
+
         memberRepository.deleteByMemberId(memberId);
-        publisher.publishEvent(new MemberDeleteEvent(tripIds, memberId));
     }
 }


### PR DESCRIPTION
## 📄 Summary
> #797 

## 🙋🏻 More
> 슬랙에 오류 알림 떴길래..그냥 간단히 예외처리 추가함..

여행 없으면 삭제 요청하지 않도록 if문 추가했습니다.
이 과정에서 애매한게 생겼는데 MemberDeleteEvent도 발행을 안하는게 맞는건지?
MemberDeleteEvent라는 네이밍만 놓고 보면 여행 존재 여부와 상관없이 계정이 삭제되면 발행되야할것같은데, 실제로 해당 이벤트가 발행되었을 때 동작하는 것은 해당 계정의 여행 삭제밖에 없어서, 그 코드에서 오류가 납니다.
즉 여행이 없으면 해당 이벤트를 발행하지 않아야 오류가 발생하지 않아요. 
예외처리를 이벤트를 받는쪽에서 해도 되긴 한데, 그럼 이벤트 발행 이유 자체가 없어져서 낭비라고 판단했습니다.

네이밍을 바꿀까요? 아니면 다른 좋은 의견 있으시면 남겨주시면 감사하겠습니다.
